### PR TITLE
Guard delayed agent prompt sends

### DIFF
--- a/src/terminals/TerminalSessionStore.ts
+++ b/src/terminals/TerminalSessionStore.ts
@@ -37,6 +37,7 @@ interface StoredTerminalSession {
 
 export class TerminalSessionStore implements vscode.Disposable {
   private readonly closeDisposable: vscode.Disposable;
+  private readonly pendingInitialPromptTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly sessionsChangedEmitter = new vscode.EventEmitter<void>();
   private readonly sessionsById = new Map<string, StoredTerminalSession>();
 
@@ -44,6 +45,7 @@ export class TerminalSessionStore implements vscode.Disposable {
     this.closeDisposable = vscode.window.onDidCloseTerminal((terminal) => {
       for (const [id, session] of this.sessionsById) {
         if (session.terminal === terminal) {
+          this.clearPendingInitialPrompt(id);
           this.sessionsById.delete(id);
           this.sessionsChangedEmitter.fire();
         }
@@ -158,9 +160,17 @@ export class TerminalSessionStore implements vscode.Disposable {
 
     const initialPrompt = launchPlan.initialPrompt;
     if (initialPrompt) {
-      setTimeout(() => {
+      const timer = setTimeout(() => {
+        this.pendingInitialPromptTimers.delete(id);
+
+        const activeSession = this.sessionsById.get(id);
+        if (!activeSession || activeSession.terminal !== terminal) {
+          return;
+        }
+
         terminal.sendText(initialPrompt, true);
       }, 200);
+      this.pendingInitialPromptTimers.set(id, timer);
     }
 
     return {
@@ -196,10 +206,24 @@ export class TerminalSessionStore implements vscode.Disposable {
 
   public dispose(): void {
     this.closeDisposable.dispose();
+    for (const timer of this.pendingInitialPromptTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.pendingInitialPromptTimers.clear();
     for (const session of this.sessionsById.values()) {
       session.terminal.dispose();
     }
     this.sessionsChangedEmitter.dispose();
     this.sessionsById.clear();
+  }
+
+  private clearPendingInitialPrompt(id: string): void {
+    const timer = this.pendingInitialPromptTimers.get(id);
+    if (!timer) {
+      return;
+    }
+
+    clearTimeout(timer);
+    this.pendingInitialPromptTimers.delete(id);
   }
 }

--- a/test/terminals/TerminalSessionStore.test.ts
+++ b/test/terminals/TerminalSessionStore.test.ts
@@ -141,6 +141,30 @@ describe("TerminalSessionStore", () => {
     store.dispose();
   });
 
+  it("does not send a delayed prompt after the terminal has already closed", async () => {
+    configurationValues.claudeCommand = process.execPath;
+
+    const { TerminalSessionStore } = await import("../../src/terminals");
+    const store = new TerminalSessionStore();
+
+    const result = store.createAgentSession({
+      cwd: "/workspace",
+      itemDescription: "Look into the regression",
+      itemId: "item-1",
+      itemTitle: "Investigate regression",
+      profileId: "claude-context",
+    });
+
+    expect(result.error).toBeNull();
+
+    closeListeners[0]?.(createdTerminals[0]);
+    vi.runAllTimers();
+
+    expect(createdTerminals[0].sendText).not.toHaveBeenCalled();
+
+    store.dispose();
+  });
+
   it("reports missing commands for unavailable profiles", async () => {
     configurationValues.claudeCommand = "definitely-missing-command-for-test";
 


### PR DESCRIPTION
## Summary
- cancel delayed initial prompt sends when a terminal closes or the session store disposes
- guard the delayed callback so it only sends text for still-active sessions
- add regression coverage for closing an agent terminal before the delayed send fires

## Validation
- npm install --offline
- npm run check
- npm run build

Closes #13