### PR TITLE
Add profile manager and Strands profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ The extension-host side owns VS Code API integration, persistence, terminal life
 - `src/terminals/TerminalSessionStore.ts` - creates shell and agent terminals, persists recoverable session metadata, restores saved sessions, and refocuses terminals
 - `src/terminals/TerminalSessionPersistence.ts` - loads and saves `.work-terminal/terminal-sessions.v1.json`, with atomic writes and corrupt snapshot recovery
 - `src/agents/AgentLauncher.ts` - resolves configured commands, splits quoted arguments, validates executables, and builds launch plans
-- `src/agents/AgentProfile.ts` - defines built-in Claude and Copilot profiles plus the work-item context prompt format
+- `src/agents/AgentProfile.ts` - defines the built-in Claude, Copilot, and Strands defaults plus the work-item context prompt format
+- `src/agents/AgentProfileConfiguration.ts` - loads profile settings, validates custom profiles, and serializes profile edits
 
 ### Webview
 
@@ -200,12 +201,15 @@ VS Code does not expose raw terminal output streams or a first-class terminal re
 
 Current launch-related settings contributed by the extension:
 
+- `workTerminal.agentProfiles` - optional full profile list for custom profiles, ordering, and built-in overrides
 - `workTerminal.claudeCommand`
 - `workTerminal.claudeExtraArgs`
 - `workTerminal.copilotCommand`
 - `workTerminal.copilotExtraArgs`
+- `workTerminal.strandsCommand`
+- `workTerminal.strandsExtraArgs`
 
-These settings are the supported way to point the extension at local Claude or Copilot CLI binaries.
+If `workTerminal.agentProfiles` is unset, Work Terminal derives the built-in Claude, Copilot, and Strands profiles from the legacy command settings above. Once a profile list is saved from `Work Terminal: Manage Profiles`, that ordered list becomes the source of truth.
 
 ## Tests and validation
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
       {
         "command": "workTerminal.createWorkItem",
         "title": "Work Terminal: Create Work Item"
+      },
+      {
+        "command": "workTerminal.manageProfiles",
+        "title": "Work Terminal: Manage Profiles"
       }
     ],
     "viewsContainers": {
@@ -76,6 +80,63 @@
           "type": "string",
           "default": "",
           "description": "Extra arguments appended when launching Copilot sessions."
+        },
+        "workTerminal.strandsCommand": {
+          "type": "string",
+          "default": "strands",
+          "description": "Command used to launch Strands sessions."
+        },
+        "workTerminal.strandsExtraArgs": {
+          "type": "string",
+          "default": "",
+          "description": "Extra arguments appended when launching Strands sessions."
+        },
+        "workTerminal.agentProfiles": {
+          "type": "array",
+          "markdownDescription": "Optional full profile configuration. When unset, Work Terminal derives the built-in Claude, Copilot, and Strands profiles from the legacy command settings. Use the `Work Terminal: Manage Profiles` command or edit this setting directly for custom profiles and ordering.",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "label",
+              "kind",
+              "command"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Stable profile id used for launches and restored sessions."
+              },
+              "label": {
+                "type": "string",
+                "description": "User-facing profile label."
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "claude",
+                  "copilot",
+                  "strands",
+                  "custom"
+                ],
+                "description": "Profile behavior. Claude adds resume session ids. The other kinds launch the configured command directly."
+              },
+              "command": {
+                "type": "string",
+                "description": "Command used to launch the profile. Multi-token commands are supported."
+              },
+              "extraArgs": {
+                "type": "string",
+                "default": "",
+                "description": "Extra arguments appended after the command tokens."
+              },
+              "usesContext": {
+                "type": "boolean",
+                "default": false,
+                "description": "When true, Work Terminal sends the work item context prompt after launch."
+              }
+            }
+          }
         }
       }
     }

--- a/src/agents/AgentLauncher.ts
+++ b/src/agents/AgentLauncher.ts
@@ -1,11 +1,7 @@
 import { accessSync, constants, statSync } from "node:fs";
 import { delimiter, isAbsolute, join, resolve, win32 } from "node:path";
 
-import {
-  getBuiltInAgentProfiles,
-  type AgentProfile,
-  type AgentProfileSummary,
-} from "./AgentProfile";
+import { getResumeBehaviorLabel, type AgentProfile, type AgentProfileSummary } from "./AgentProfile";
 
 const DEFAULT_WINDOWS_PATHEXT = ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC";
 
@@ -17,13 +13,11 @@ export interface AgentLaunchPlan {
 }
 
 export function buildAgentLaunchPlan(options: {
-  readonly configuredCommand: string;
-  readonly configuredExtraArgs: string;
   readonly contextPrompt: string | null;
   readonly profile: AgentProfile;
   readonly resumeSessionId?: string | null;
 }): AgentLaunchPlan {
-  const commandTokens = splitConfiguredCommand(options.configuredCommand.trim());
+  const commandTokens = splitConfiguredCommand(options.profile.command.trim());
 
   if (commandTokens.length === 0) {
     throw new Error(`No command configured for ${options.profile.label}.`);
@@ -31,7 +25,7 @@ export function buildAgentLaunchPlan(options: {
 
   const executable = commandTokens[0];
   const baseArgs = commandTokens.slice(1);
-  const extraArgs = splitConfiguredCommand(options.configuredExtraArgs.trim());
+  const extraArgs = splitConfiguredCommand(options.profile.extraArgs.trim());
   const sessionId = options.profile.kind === "claude" ? options.resumeSessionId ?? crypto.randomUUID() : null;
   const agentArgs = options.profile.kind === "claude" && sessionId ? ["--session-id", sessionId] : [];
 
@@ -43,27 +37,23 @@ export function buildAgentLaunchPlan(options: {
   };
 }
 
-export function getAgentProfileSummaries(configuration: {
-  get<T>(section: string, defaultValue?: T): T;
-}): readonly AgentProfileSummary[] {
-  return getBuiltInAgentProfiles().map((profile) => {
-    const command = getNormalizedConfiguredCommand(
-      configuration.get<string>(profile.commandConfigurationKey, profile.defaultCommand),
-      profile.defaultCommand,
-    );
-    const resolvedCommand = resolveConfiguredCommand(command);
+export function getAgentProfileSummaries(profiles: readonly AgentProfile[]): readonly AgentProfileSummary[] {
+  return profiles.map((profile) => {
+    const normalizedCommand = profile.command.trim();
+    const resolvedCommand = resolveConfiguredCommand(normalizedCommand);
+    const status = normalizedCommand.length === 0
+      ? "invalid-configuration"
+      : (resolvedCommand.found ? "ready" : "missing-command");
 
     return {
-      command,
-      id: profile.id,
-      kind: profile.kind,
-      label: profile.label,
-      resumeBehaviorLabel: profile.resumeBehaviorLabel,
-      status: resolvedCommand.found ? "ready" : "missing-command",
-      statusLabel: resolvedCommand.found
-        ? `Ready - ${resolvedCommand.resolved}`
-        : `Missing from PATH - ${command || profile.defaultCommand}`,
-      usesContext: profile.usesContext,
+      ...profile,
+      resumeBehaviorLabel: getResumeBehaviorLabel(profile),
+      status,
+      statusLabel: normalizedCommand.length === 0
+        ? "Invalid configuration - add a launch command."
+        : (resolvedCommand.found
+          ? `Ready - ${resolvedCommand.resolved}`
+          : `Missing from PATH - ${normalizedCommand}`),
     };
   });
 }
@@ -130,14 +120,6 @@ export function splitConfiguredCommand(command: string): string[] {
   }
 
   return tokens;
-}
-
-export function getNormalizedConfiguredCommand(
-  configuredCommand: string | undefined,
-  defaultCommand: string,
-): string {
-  const trimmed = configuredCommand?.trim() ?? "";
-  return trimmed || defaultCommand;
 }
 
 function resolveConfiguredCommand(command: string): { readonly found: boolean; readonly resolved: string } {

--- a/src/agents/AgentProfile.ts
+++ b/src/agents/AgentProfile.ts
@@ -1,77 +1,125 @@
-export type AgentKind = "claude" | "copilot";
-export type AgentProfileId = "claude" | "claude-context" | "copilot" | "copilot-context";
+export const AGENT_KINDS = ["claude", "copilot", "strands", "custom"] as const;
+export type AgentKind = (typeof AGENT_KINDS)[number];
+export type AgentProfileId = string;
 
 export interface AgentProfile {
-  readonly commandConfigurationKey: string;
-  readonly defaultCommand: string;
-  readonly extraArgsConfigurationKey: string;
+  readonly builtIn: boolean;
+  readonly command: string;
+  readonly extraArgs: string;
   readonly id: AgentProfileId;
   readonly kind: AgentKind;
   readonly label: string;
-  readonly resumeBehaviorLabel: string;
   readonly usesContext: boolean;
 }
 
-export interface AgentProfileSummary {
+export interface AgentProfileIssue {
+  readonly message: string;
+  readonly profileId: AgentProfileId | null;
+}
+
+export interface AgentProfileSummary extends AgentProfile {
+  readonly resumeBehaviorLabel: string;
+  readonly status: "invalid-configuration" | "missing-command" | "ready";
+  readonly statusLabel: string;
+}
+
+export interface SerializedAgentProfile {
   readonly command: string;
+  readonly extraArgs?: string;
   readonly id: AgentProfileId;
   readonly kind: AgentKind;
   readonly label: string;
-  readonly resumeBehaviorLabel: string;
-  readonly status: "missing-command" | "ready";
-  readonly statusLabel: string;
-  readonly usesContext: boolean;
+  readonly usesContext?: boolean;
 }
 
 const BUILT_IN_AGENT_PROFILES: readonly AgentProfile[] = [
   {
-    commandConfigurationKey: "claudeCommand",
-    defaultCommand: "claude",
-    extraArgsConfigurationKey: "claudeExtraArgs",
+    builtIn: true,
+    command: "claude",
+    extraArgs: "",
     id: "claude",
     kind: "claude",
     label: "Claude",
-    resumeBehaviorLabel: "Tracks a launch session id for resume-aware workflows.",
     usesContext: false,
   },
   {
-    commandConfigurationKey: "claudeCommand",
-    defaultCommand: "claude",
-    extraArgsConfigurationKey: "claudeExtraArgs",
+    builtIn: true,
+    command: "claude",
+    extraArgs: "",
     id: "claude-context",
     kind: "claude",
     label: "Claude (ctx)",
-    resumeBehaviorLabel: "Tracks a launch session id and sends work item context after launch.",
     usesContext: true,
   },
   {
-    commandConfigurationKey: "copilotCommand",
-    defaultCommand: "copilot",
-    extraArgsConfigurationKey: "copilotExtraArgs",
+    builtIn: true,
+    command: "copilot",
+    extraArgs: "",
     id: "copilot",
     kind: "copilot",
     label: "Copilot",
-    resumeBehaviorLabel: "Launches GitHub Copilot CLI with the configured command.",
     usesContext: false,
   },
   {
-    commandConfigurationKey: "copilotCommand",
-    defaultCommand: "copilot",
-    extraArgsConfigurationKey: "copilotExtraArgs",
+    builtIn: true,
+    command: "copilot",
+    extraArgs: "",
     id: "copilot-context",
     kind: "copilot",
     label: "Copilot (ctx)",
-    resumeBehaviorLabel: "Launches GitHub Copilot CLI and sends work item context after launch.",
+    usesContext: true,
+  },
+  {
+    builtIn: true,
+    command: "strands",
+    extraArgs: "",
+    id: "strands",
+    kind: "strands",
+    label: "Strands",
+    usesContext: false,
+  },
+  {
+    builtIn: true,
+    command: "strands",
+    extraArgs: "",
+    id: "strands-context",
+    kind: "strands",
+    label: "Strands (ctx)",
     usesContext: true,
   },
 ] as const;
 
 export function getBuiltInAgentProfiles(): readonly AgentProfile[] {
-  return BUILT_IN_AGENT_PROFILES;
+  return BUILT_IN_AGENT_PROFILES.map((profile) => ({ ...profile }));
 }
 
-export function getAgentProfileById(profileId: string): AgentProfile | null {
+export function getBuiltInAgentProfileById(profileId: string): AgentProfile | null {
   return BUILT_IN_AGENT_PROFILES.find((profile) => profile.id === profileId) ?? null;
+}
+
+export function isAgentKind(value: string): value is AgentKind {
+  return AGENT_KINDS.includes(value as AgentKind);
+}
+
+export function getResumeBehaviorLabel(profile: Pick<AgentProfile, "kind" | "usesContext">): string {
+  switch (profile.kind) {
+    case "claude":
+      return profile.usesContext
+        ? "Tracks a launch session id and sends work item context after launch."
+        : "Tracks a launch session id for resume-aware workflows.";
+    case "copilot":
+      return profile.usesContext
+        ? "Launches GitHub Copilot CLI and sends work item context after launch."
+        : "Launches GitHub Copilot CLI with the configured command.";
+    case "strands":
+      return profile.usesContext
+        ? "Launches Strands and sends work item context after launch."
+        : "Launches Strands with the configured command.";
+    case "custom":
+      return profile.usesContext
+        ? "Launches the configured agent command and sends work item context after launch."
+        : "Launches the configured agent command.";
+  }
 }
 
 export function buildWorkItemContextPrompt(itemTitle: string, itemDescription: string | null): string {

--- a/src/agents/AgentProfileConfiguration.ts
+++ b/src/agents/AgentProfileConfiguration.ts
@@ -1,0 +1,191 @@
+import {
+  getBuiltInAgentProfileById,
+  getBuiltInAgentProfiles,
+  isAgentKind,
+  type AgentProfile,
+  type AgentProfileIssue,
+  type AgentProfileId,
+  type SerializedAgentProfile,
+} from "./AgentProfile";
+
+export const AGENT_PROFILES_CONFIGURATION_KEY = "agentProfiles";
+
+interface ConfigurationLike {
+  get<T>(section: string, defaultValue?: T): T;
+}
+
+export interface AgentProfileCatalog {
+  readonly issues: readonly AgentProfileIssue[];
+  readonly profiles: readonly AgentProfile[];
+}
+
+export function loadAgentProfileCatalog(configuration: ConfigurationLike): AgentProfileCatalog {
+  const configuredProfiles = configuration.get<unknown>(AGENT_PROFILES_CONFIGURATION_KEY);
+  if (configuredProfiles === undefined) {
+    return {
+      issues: [],
+      profiles: buildLegacyBackedProfiles(configuration),
+    };
+  }
+
+  if (!Array.isArray(configuredProfiles)) {
+    return {
+      issues: [{ message: "workTerminal.agentProfiles must be an array. Using built-in defaults until the setting is fixed.", profileId: null }],
+      profiles: buildLegacyBackedProfiles(configuration),
+    };
+  }
+
+  const profiles: AgentProfile[] = [];
+  const issues: AgentProfileIssue[] = [];
+  const seenIds = new Set<string>();
+
+  for (const [index, profileValue] of configuredProfiles.entries()) {
+    const normalized = normalizeSerializedAgentProfile(profileValue);
+    if (!normalized.profile) {
+      issues.push({
+        message: `Profile entry ${index + 1}: ${normalized.issue}`,
+        profileId: normalized.profileId,
+      });
+      continue;
+    }
+
+    if (seenIds.has(normalized.profile.id)) {
+      issues.push({
+        message: `Profile "${normalized.profile.id}" is duplicated. Keep each profile id unique.`,
+        profileId: normalized.profile.id,
+      });
+      continue;
+    }
+
+    seenIds.add(normalized.profile.id);
+    profiles.push(normalized.profile);
+  }
+
+  return { issues, profiles };
+}
+
+export function getAgentProfileById(
+  configuration: ConfigurationLike,
+  profileId: AgentProfileId,
+): AgentProfile | null {
+  return loadAgentProfileCatalog(configuration).profiles.find((profile) => profile.id === profileId) ?? null;
+}
+
+export function serializeAgentProfiles(profiles: readonly AgentProfile[]): readonly SerializedAgentProfile[] {
+  return profiles.map((profile) => ({
+    command: profile.command,
+    extraArgs: profile.extraArgs,
+    id: profile.id,
+    kind: profile.kind,
+    label: profile.label,
+    usesContext: profile.usesContext,
+  }));
+}
+
+function buildLegacyBackedProfiles(configuration: ConfigurationLike): readonly AgentProfile[] {
+  return getBuiltInAgentProfiles().map((profile) => ({
+    ...profile,
+    command: getLegacyCommandOverride(configuration, profile),
+    extraArgs: getLegacyExtraArgsOverride(configuration, profile),
+  }));
+}
+
+function getLegacyCommandOverride(
+  configuration: ConfigurationLike,
+  profile: Pick<AgentProfile, "command" | "kind">,
+): string {
+  switch (profile.kind) {
+    case "claude":
+      return normalizeString(configuration.get<string>("claudeCommand", profile.command), profile.command);
+    case "copilot":
+      return normalizeString(configuration.get<string>("copilotCommand", profile.command), profile.command);
+    case "strands":
+      return normalizeString(configuration.get<string>("strandsCommand", profile.command), profile.command);
+    case "custom":
+      return profile.command;
+  }
+}
+
+function getLegacyExtraArgsOverride(
+  configuration: ConfigurationLike,
+  profile: Pick<AgentProfile, "extraArgs" | "kind">,
+): string {
+  switch (profile.kind) {
+    case "claude":
+      return normalizeString(configuration.get<string>("claudeExtraArgs", profile.extraArgs), profile.extraArgs);
+    case "copilot":
+      return normalizeString(configuration.get<string>("copilotExtraArgs", profile.extraArgs), profile.extraArgs);
+    case "strands":
+      return normalizeString(configuration.get<string>("strandsExtraArgs", profile.extraArgs), profile.extraArgs);
+    case "custom":
+      return profile.extraArgs;
+  }
+}
+
+function normalizeSerializedAgentProfile(value: unknown): {
+  readonly issue: string | null;
+  readonly profile: AgentProfile | null;
+  readonly profileId: AgentProfileId | null;
+} {
+  if (!isRecord(value)) {
+    return { issue: "must be an object.", profile: null, profileId: null };
+  }
+
+  const rawId = asTrimmedString(value.id);
+  if (!rawId) {
+    return { issue: "is missing a non-empty id.", profile: null, profileId: null };
+  }
+
+  const rawLabel = asTrimmedString(value.label);
+  if (!rawLabel) {
+    return { issue: "must include a non-empty label.", profile: null, profileId: rawId };
+  }
+
+  const rawKind = asTrimmedString(value.kind);
+  if (!rawKind || !isAgentKind(rawKind)) {
+    return {
+      issue: `must use one of ${["claude", "copilot", "strands", "custom"].join(", ")} as the kind.`,
+      profile: null,
+      profileId: rawId,
+    };
+  }
+
+  const rawCommand = asTrimmedString(value.command);
+  if (!rawCommand) {
+    return {
+      issue: "must include a non-empty command.",
+      profile: null,
+      profileId: rawId,
+    };
+  }
+
+  const extraArgs = typeof value.extraArgs === "string" ? value.extraArgs : "";
+  const usesContext = typeof value.usesContext === "boolean" ? value.usesContext : false;
+
+  return {
+    issue: null,
+    profile: {
+      builtIn: Boolean(getBuiltInAgentProfileById(rawId)),
+      command: rawCommand,
+      extraArgs,
+      id: rawId,
+      kind: rawKind,
+      label: rawLabel,
+      usesContext,
+    },
+    profileId: rawId,
+  };
+}
+
+function normalizeString(value: string | undefined, defaultValue: string): string {
+  const trimmed = value?.trim() ?? "";
+  return trimmed || defaultValue;
+}
+
+function asTrimmedString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,15 +1,26 @@
 export {
+  AGENT_KINDS,
   buildWorkItemContextPrompt,
-  getAgentProfileById,
+  getBuiltInAgentProfileById,
   getBuiltInAgentProfiles,
+  getResumeBehaviorLabel,
+  isAgentKind,
   type AgentKind,
   type AgentProfile,
   type AgentProfileId,
+  type AgentProfileIssue,
   type AgentProfileSummary,
+  type SerializedAgentProfile,
 } from "./AgentProfile";
 export {
+  AGENT_PROFILES_CONFIGURATION_KEY,
+  getAgentProfileById,
+  loadAgentProfileCatalog,
+  serializeAgentProfiles,
+  type AgentProfileCatalog,
+} from "./AgentProfileConfiguration";
+export {
   buildAgentLaunchPlan,
-  getNormalizedConfiguredCommand,
   getAgentProfileSummaries,
   splitConfiguredCommand,
   type AgentLaunchPlan,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand("workTerminal.createWorkItem", async () => {
       await provider.createWorkItemFromPrompt();
     }),
+    vscode.commands.registerCommand("workTerminal.manageProfiles", async () => {
+      await vscode.commands.executeCommand("workbench.view.extension.workTerminal");
+      await provider.manageProfilesFromPrompt();
+    }),
   );
 }
 

--- a/src/terminals/TerminalSessionPersistence.ts
+++ b/src/terminals/TerminalSessionPersistence.ts
@@ -1,15 +1,13 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
-import type { AgentProfileId } from "../agents";
-
 const STORAGE_DIRECTORY_NAME = ".work-terminal";
 const STORAGE_FILE_NAME = "terminal-sessions.v1.json";
 const SNAPSHOT_VERSION = 1;
 const MAX_RECENTLY_CLOSED_SESSIONS = 12;
 const RECENTLY_CLOSED_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
-type PersistedTerminalSessionKind = "claude" | "copilot" | "shell";
+type PersistedTerminalSessionKind = "claude" | "copilot" | "custom" | "shell" | "strands";
 
 export interface PersistedTerminalSession {
   readonly command: string | null;
@@ -20,7 +18,7 @@ export interface PersistedTerminalSession {
   readonly itemTitle: string;
   readonly kind: PersistedTerminalSessionKind;
   readonly label: string;
-  readonly profileId: AgentProfileId | null;
+  readonly profileId: string | null;
   readonly profileLabel: string | null;
   readonly resumeSessionId: string | null;
   readonly statusLabel: string;
@@ -329,13 +327,8 @@ function normalizeRecentlyClosedTerminalSession(input: unknown): RecentlyClosedT
   };
 }
 
-function asAgentProfileId(value: unknown): AgentProfileId | null {
-  return value === "claude" ||
-      value === "claude-context" ||
-      value === "copilot" ||
-      value === "copilot-context"
-    ? value
-    : null;
+function asAgentProfileId(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
 function asNullableString(value: unknown): string | null {
@@ -347,7 +340,9 @@ function asNonEmptyString(value: unknown): string | null {
 }
 
 function asSessionKind(value: unknown): PersistedTerminalSessionKind | null {
-  return value === "claude" || value === "copilot" || value === "shell" ? value : null;
+  return value === "claude" || value === "copilot" || value === "custom" || value === "shell" || value === "strands"
+    ? value
+    : null;
 }
 
 function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {

--- a/src/terminals/TerminalSessionPersistence.ts
+++ b/src/terminals/TerminalSessionPersistence.ts
@@ -328,7 +328,12 @@ function normalizeRecentlyClosedTerminalSession(input: unknown): RecentlyClosedT
 }
 
 function asAgentProfileId(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value : null;
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 function asNullableString(value: unknown): string | null {

--- a/src/terminals/TerminalSessionStore.ts
+++ b/src/terminals/TerminalSessionStore.ts
@@ -3,10 +3,10 @@ import * as vscode from "vscode";
 import {
   buildAgentLaunchPlan,
   buildWorkItemContextPrompt,
-  getAgentProfileById,
-  getNormalizedConfiguredCommand,
   getAgentProfileSummaries,
+  loadAgentProfileCatalog,
   type AgentProfileId,
+  type AgentProfileIssue,
   type AgentProfileSummary,
 } from "../agents";
 import {
@@ -29,7 +29,7 @@ export interface TerminalSessionSummary {
   readonly itemDescription: string | null;
   readonly itemId: string;
   readonly itemTitle: string;
-  readonly kind: "claude" | "copilot" | "shell";
+  readonly kind: "claude" | "copilot" | "custom" | "shell" | "strands";
   readonly label: string;
   readonly profileId: AgentProfileId | null;
   readonly profileLabel: string | null;
@@ -39,6 +39,7 @@ export interface TerminalSessionSummary {
 
 export interface TerminalStoreSummary {
   readonly agentProfiles: readonly AgentProfileSummary[];
+  readonly profileIssues: readonly AgentProfileIssue[];
   readonly recentlyClosedSessions: readonly RecentlyClosedTerminalSession[];
   readonly sessionCountByItemId: Record<string, number>;
   readonly sessions: readonly TerminalSessionSummary[];
@@ -176,37 +177,29 @@ export class TerminalSessionStore implements vscode.Disposable {
       readonly skipInitialPrompt?: boolean;
     } = {},
   ): Promise<{ readonly error: string | null; readonly session: TerminalSessionSummary | null }> {
-    const configuration = vscode.workspace.getConfiguration("workTerminal");
-    const profile = getAgentProfileById(options.profileId);
+    const catalog = loadAgentProfileCatalog(vscode.workspace.getConfiguration("workTerminal"));
+    const profile = catalog.profiles.find((candidate) => candidate.id === options.profileId);
 
     if (!profile) {
       return {
-        error: `Unknown agent profile "${options.profileId}".`,
+        error: `Unknown agent profile "${options.profileId}". Use Manage Profiles to add it back or choose a different profile.`,
         session: null,
       };
     }
 
-    const profileSummary = getAgentProfileSummaries(configuration).find((summary) => summary.id === options.profileId);
+    const profileSummary = getAgentProfileSummaries(catalog.profiles).find((summary) => summary.id === options.profileId);
     if (!profileSummary || profileSummary.status !== "ready") {
       return {
-        error: `${profile.label} is not available. ${profileSummary?.statusLabel ?? "Check the configured command in settings."}`,
+        error: `${profile.label} is not available. ${profileSummary?.statusLabel ?? "Check the profile configuration in Manage Profiles or settings."}`,
         session: null,
       };
     }
-
-    const configuredCommand = getNormalizedConfiguredCommand(
-      configuration.get<string>(profile.commandConfigurationKey, profile.defaultCommand),
-      profile.defaultCommand,
-    );
-    const configuredExtraArgs = configuration.get<string>(profile.extraArgsConfigurationKey, "") ?? "";
     const contextPrompt = createOptions.skipInitialPrompt
       ? null
       : buildWorkItemContextPrompt(options.itemTitle, options.itemDescription);
     let launchPlan;
     try {
       launchPlan = buildAgentLaunchPlan({
-        configuredCommand,
-        configuredExtraArgs,
         contextPrompt,
         profile,
         resumeSessionId: createOptions.resumeSessionId,
@@ -233,7 +226,7 @@ export class TerminalSessionStore implements vscode.Disposable {
     const summary: TerminalSessionSummary = {
       activityState: "active",
       activityStateLabel: "Launching agent session",
-      command: configuredCommand.trim(),
+      command: profile.command.trim(),
       id,
       itemDescription: options.itemDescription,
       itemId: options.itemId,
@@ -401,8 +394,11 @@ export class TerminalSessionStore implements vscode.Disposable {
       sessionCountByItemId[session.itemId] = (sessionCountByItemId[session.itemId] ?? 0) + 1;
     }
 
+    const catalog = loadAgentProfileCatalog(vscode.workspace.getConfiguration("workTerminal"));
+
     return {
-      agentProfiles: getAgentProfileSummaries(vscode.workspace.getConfiguration("workTerminal")),
+      agentProfiles: getAgentProfileSummaries(catalog.profiles),
+      profileIssues: catalog.issues,
       recentlyClosedSessions: this.recentlyClosedSessions,
       sessionCountByItemId,
       sessions,
@@ -764,7 +760,8 @@ function shouldSkipInitialPromptOnRestore(
     return false;
   }
 
-  const profile = getAgentProfileById(profileId);
+  const profile = loadAgentProfileCatalog(vscode.workspace.getConfiguration("workTerminal")).profiles
+    .find((candidate) => candidate.id === profileId);
   return Boolean(profile && profile.kind === "claude" && profile.usesContext);
 }
 

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -2,12 +2,13 @@ import "./styles.css";
 
 interface WorkTerminalViewState {
   readonly agentProfiles: ReadonlyArray<{
+    readonly builtIn: boolean;
     readonly command: string;
     readonly id: string;
-    readonly kind: "claude" | "copilot";
+    readonly kind: "claude" | "copilot" | "custom" | "strands";
     readonly label: string;
     readonly resumeBehaviorLabel: string;
-    readonly status: "missing-command" | "ready";
+    readonly status: "invalid-configuration" | "missing-command" | "ready";
     readonly statusLabel: string;
     readonly usesContext: boolean;
   }>;
@@ -31,6 +32,10 @@ interface WorkTerminalViewState {
     readonly label: string;
   }>;
   readonly latestWorkItemTitle: string | null;
+  readonly profileIssues: ReadonlyArray<{
+    readonly message: string;
+    readonly profileId: string | null;
+  }>;
   readonly selectedItemId: string | null;
   readonly recentlyClosedSessions: ReadonlyArray<{
     readonly closedAt: string;
@@ -39,7 +44,7 @@ interface WorkTerminalViewState {
     readonly itemDescription: string | null;
     readonly itemId: string;
     readonly itemTitle: string;
-    readonly kind: "claude" | "copilot" | "shell";
+    readonly kind: "claude" | "copilot" | "custom" | "shell" | "strands";
     readonly label: string;
     readonly profileId: string | null;
     readonly profileLabel: string | null;
@@ -57,7 +62,7 @@ interface WorkTerminalViewState {
     readonly itemDescription: string | null;
     readonly itemId: string;
     readonly itemTitle: string;
-    readonly kind: "claude" | "copilot" | "shell";
+    readonly kind: "claude" | "copilot" | "custom" | "shell" | "strands";
     readonly label: string;
     readonly profileId: string | null;
     readonly profileLabel: string | null;
@@ -145,6 +150,11 @@ root.addEventListener("click", (event: MouseEvent) => {
 
   if (target.dataset.action === "create") {
     vscode.postMessage({ type: "create-work-item-requested" });
+    return;
+  }
+
+  if (target.dataset.action === "manage-profiles") {
+    vscode.postMessage({ type: "manage-profiles-requested" });
     return;
   }
 
@@ -349,6 +359,7 @@ function render(nextState: WorkTerminalViewState): void {
             data-action="filter-items"
           />
           <button class="ghost-button" type="button" data-action="create">Create work item</button>
+          <button class="ghost-button" type="button" data-action="manage-profiles">Manage profiles</button>
           <button class="ghost-button" type="button" data-action="refresh">Refresh view</button>
         </div>
       </header>
@@ -482,7 +493,10 @@ function render(nextState: WorkTerminalViewState): void {
           </div>
           <div class="placeholder-stack">
             <article class="card">
-              <h3>Agent launchers</h3>
+              <div class="card-title-row">
+                <h3>Agent launchers</h3>
+                <button class="ghost-button" type="button" data-action="manage-profiles">Manage profiles</button>
+              </div>
               <ul class="profile-list">
                 ${nextState.agentProfiles
                   .map(
@@ -490,6 +504,7 @@ function render(nextState: WorkTerminalViewState): void {
                       <li class="profile-list-item">
                         <div>
                           <strong>${escapeHtml(profile.label)}</strong>
+                          <p>${escapeHtml(`${capitalize(profile.kind)}${profile.usesContext ? " · ctx" : ""}${profile.builtIn ? " · built-in" : ""}`)}</p>
                           <p>${escapeHtml(profile.resumeBehaviorLabel)}</p>
                         </div>
                         <div class="profile-status ${profile.status === "ready" ? "is-ready" : "is-missing"}">${escapeHtml(profile.statusLabel)}</div>
@@ -569,9 +584,18 @@ function render(nextState: WorkTerminalViewState): void {
               }
             </article>
             <article class="card">
+              <h3>Profile diagnostics</h3>
+              ${nextState.profileIssues.length > 0
+                ? `<ul class="profile-issue-list">${nextState.profileIssues
+                  .map((issue) => `<li>${escapeHtml(issue.profileId ? `${issue.profileId}: ${issue.message}` : issue.message)}</li>`)
+                  .join("")}</ul>`
+                : "<p>No profile configuration issues detected.</p>"}
+              <p class="session-meta">Fix issues in Manage Profiles or directly in the workTerminal.agentProfiles setting.</p>
+            </article>
+            <article class="card">
               <h3>Host-managed sessions</h3>
               <p>${escapeHtml(nextState.status)}</p>
-              <p>Shell, Claude, and Copilot sessions opened from the board are tracked here by work item.</p>
+              <p>Shell, Claude, Copilot, Strands, and custom sessions opened from the board are tracked here by work item.</p>
             </article>
           </div>
         </section>
@@ -640,6 +664,7 @@ function createFallbackState(): WorkTerminalViewState {
     },
     columnSummaries: [],
     latestWorkItemTitle: null,
+    profileIssues: [],
     recentlyClosedSessions: [],
     selectedItemId: null,
     status: "Scaffold ready",

--- a/src/webview/styles.css
+++ b/src/webview/styles.css
@@ -231,6 +231,23 @@ select {
   margin: 0;
 }
 
+.card-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.profile-issue-list {
+  margin: 12px 0 0;
+  padding-left: 18px;
+  color: var(--vscode-errorForeground, var(--vscode-foreground));
+}
+
+.profile-issue-list li + li {
+  margin-top: 6px;
+}
+
 .card p,
 .topbar p {
   margin: 6px 0 0;

--- a/src/workTerminal/WorkTerminalViewProvider.ts
+++ b/src/workTerminal/WorkTerminalViewProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 
 import {
+  AGENT_PROFILES_CONFIGURATION_KEY,
   getBuiltInAgentProfileById,
   loadAgentProfileCatalog,
   serializeAgentProfiles,
@@ -15,8 +16,6 @@ import {
   renderWorkTerminalHtml,
   type WorkTerminalViewState,
 } from "./renderWorkTerminalHtml";
-
-const AGENT_PROFILES_CONFIGURATION_SECTION = "agentProfiles";
 
 type WorkTerminalWebviewMessage =
   | { readonly type: "ready"; readonly selectedItemId: string | null }
@@ -233,7 +232,7 @@ export class WorkTerminalViewProvider implements vscode.WebviewViewProvider {
     }
 
     if (action === "reset") {
-      await configuration.update(AGENT_PROFILES_CONFIGURATION_SECTION, undefined, getConfigurationTarget());
+      await configuration.update(AGENT_PROFILES_CONFIGURATION_KEY, undefined, getConfigurationTarget());
       await this.refresh("Reset profile configuration to the built-in defaults");
       void vscode.window.showInformationMessage("Reset Work Terminal profiles to the built-in defaults.");
       return;
@@ -379,7 +378,7 @@ export class WorkTerminalViewProvider implements vscode.WebviewViewProvider {
   private async saveProfiles(profiles: readonly AgentProfile[], status: string): Promise<void> {
     const configuration = vscode.workspace.getConfiguration("workTerminal");
     await configuration.update(
-      AGENT_PROFILES_CONFIGURATION_SECTION,
+      AGENT_PROFILES_CONFIGURATION_KEY,
       serializeAgentProfiles(profiles),
       getConfigurationTarget(),
     );

--- a/src/workTerminal/WorkTerminalViewProvider.ts
+++ b/src/workTerminal/WorkTerminalViewProvider.ts
@@ -1,6 +1,13 @@
 import * as vscode from "vscode";
 
-import type { AgentProfileId } from "../agents";
+import {
+  getBuiltInAgentProfileById,
+  loadAgentProfileCatalog,
+  serializeAgentProfiles,
+  type AgentKind,
+  type AgentProfile,
+  type AgentProfileId,
+} from "../agents";
 import type { TerminalSessionStore } from "../terminals";
 import type { WorkItemStore } from "../workItems";
 import { getNonce } from "./getNonce";
@@ -9,10 +16,13 @@ import {
   type WorkTerminalViewState,
 } from "./renderWorkTerminalHtml";
 
+const AGENT_PROFILES_CONFIGURATION_SECTION = "agentProfiles";
+
 type WorkTerminalWebviewMessage =
   | { readonly type: "ready"; readonly selectedItemId: string | null }
   | { readonly type: "create-work-item-requested" }
   | { readonly type: "focus-terminal-requested"; readonly terminalId: string }
+  | { readonly type: "manage-profiles-requested" }
   | {
       readonly type: "reorder-item-requested";
       readonly fromColumn: "priority" | "todo" | "active" | "done";
@@ -93,6 +103,11 @@ export class WorkTerminalViewProvider implements vscode.WebviewViewProvider {
 
         if (message.type === "create-work-item-requested") {
           await this.createWorkItemFromPrompt();
+          return;
+        }
+
+        if (message.type === "manage-profiles-requested") {
+          await this.manageProfilesFromPrompt();
           return;
         }
 
@@ -196,6 +211,82 @@ export class WorkTerminalViewProvider implements vscode.WebviewViewProvider {
     void vscode.window.showInformationMessage(`Created work item "${item.title}".`);
   }
 
+  public async manageProfilesFromPrompt(): Promise<void> {
+    const configuration = vscode.workspace.getConfiguration("workTerminal");
+    const catalog = loadAgentProfileCatalog(configuration);
+    const profiles = [...catalog.profiles];
+    const action = await promptForProfileAction();
+
+    if (!action) {
+      return;
+    }
+
+    if (action === "create") {
+      const created = await promptForProfile(undefined, profiles.map((profile) => profile.id));
+      if (!created) {
+        return;
+      }
+
+      profiles.push(created);
+      await this.saveProfiles(profiles, `Added profile "${created.label}"`);
+      return;
+    }
+
+    if (action === "reset") {
+      await configuration.update(AGENT_PROFILES_CONFIGURATION_SECTION, undefined, getConfigurationTarget());
+      await this.refresh("Reset profile configuration to the built-in defaults");
+      void vscode.window.showInformationMessage("Reset Work Terminal profiles to the built-in defaults.");
+      return;
+    }
+
+    const selectedProfile = await promptForExistingProfile(profiles, action, catalog.issues.length);
+    if (!selectedProfile) {
+      return;
+    }
+
+    if (action === "edit") {
+      const updated = await promptForProfile(selectedProfile, profiles
+        .filter((profile) => profile.id !== selectedProfile.id)
+        .map((profile) => profile.id));
+      if (!updated) {
+        return;
+      }
+
+      const nextProfiles = profiles.map((profile) => profile.id === selectedProfile.id ? updated : profile);
+      await this.saveProfiles(nextProfiles, `Updated profile "${updated.label}"`);
+      return;
+    }
+
+    if (action === "delete") {
+      const confirmation = await vscode.window.showWarningMessage(
+        `Delete the profile "${selectedProfile.label}"?`,
+        { modal: true },
+        "Delete",
+      );
+      if (confirmation !== "Delete") {
+        return;
+      }
+
+      await this.saveProfiles(
+        profiles.filter((profile) => profile.id !== selectedProfile.id),
+        `Deleted profile "${selectedProfile.label}"`,
+      );
+      return;
+    }
+
+    const profileIndex = profiles.findIndex((profile) => profile.id === selectedProfile.id);
+    const direction = action === "move-up" ? -1 : 1;
+    const targetIndex = profileIndex + direction;
+    if (profileIndex < 0 || targetIndex < 0 || targetIndex >= profiles.length) {
+      void vscode.window.showWarningMessage(`"${selectedProfile.label}" cannot move any further.`);
+      return;
+    }
+
+    const nextProfiles = [...profiles];
+    [nextProfiles[profileIndex], nextProfiles[targetIndex]] = [nextProfiles[targetIndex], nextProfiles[profileIndex]];
+    await this.saveProfiles(nextProfiles, `Reordered profile "${selectedProfile.label}"`);
+  }
+
   public async launchShell(itemId: string, itemTitle: string, itemDescription: string | null): Promise<void> {
     const cwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     const session = await this.terminalStore.createShellSession(itemId, itemTitle, itemDescription, cwd);
@@ -269,6 +360,7 @@ export class WorkTerminalViewProvider implements vscode.WebviewViewProvider {
       collapsedColumns: summary.collapsedColumns,
       columnSummaries: summary.columnSummaries,
       latestWorkItemTitle: summary.latestWorkItemTitle,
+      profileIssues: terminalSummary.profileIssues,
       recentlyClosedSessions: terminalSummary.recentlyClosedSessions,
       selectedItemId: resolvedSelectedItemId,
       status,
@@ -282,6 +374,17 @@ export class WorkTerminalViewProvider implements vscode.WebviewViewProvider {
         "No workspace",
       lastUpdatedLabel: new Date().toLocaleTimeString(),
     };
+  }
+
+  private async saveProfiles(profiles: readonly AgentProfile[], status: string): Promise<void> {
+    const configuration = vscode.workspace.getConfiguration("workTerminal");
+    await configuration.update(
+      AGENT_PROFILES_CONFIGURATION_SECTION,
+      serializeAgentProfiles(profiles),
+      getConfigurationTarget(),
+    );
+    await this.refresh(status);
+    void vscode.window.showInformationMessage(status);
   }
 }
 
@@ -299,4 +402,172 @@ async function promptForState(): Promise<"priority" | "todo" | "active" | "done"
   });
 
   return selection?.state;
+}
+
+async function promptForProfileAction(): Promise<"create" | "delete" | "edit" | "move-down" | "move-up" | "reset" | undefined> {
+  const selection = await vscode.window.showQuickPick([
+    { label: "Create profile", value: "create" },
+    { label: "Edit profile", value: "edit" },
+    { label: "Delete profile", value: "delete" },
+    { label: "Move profile up", value: "move-up" },
+    { label: "Move profile down", value: "move-down" },
+    { label: "Reset to built-in defaults", value: "reset" },
+  ] as const, {
+    ignoreFocusOut: true,
+    placeHolder: "Manage agent profiles",
+  });
+
+  return selection?.value;
+}
+
+async function promptForExistingProfile(
+  profiles: readonly AgentProfile[],
+  action: "delete" | "edit" | "move-down" | "move-up",
+  issueCount: number,
+): Promise<AgentProfile | undefined> {
+  if (profiles.length === 0) {
+    void vscode.window.showWarningMessage("No profiles are configured yet. Create one first.");
+    return undefined;
+  }
+
+  const selection = await vscode.window.showQuickPick(
+    profiles.map((profile, index) => ({
+      description: `${profile.kind}${profile.usesContext ? " · ctx" : ""}${profile.builtIn ? " · built-in" : ""}`,
+      detail: `${index + 1}. ${profile.command}${issueCount > 0 ? ` · ${issueCount} config issue${issueCount === 1 ? "" : "s"} currently shown in the board` : ""}`,
+      label: profile.label,
+      profile,
+    })),
+    {
+      ignoreFocusOut: true,
+      placeHolder: `Select a profile to ${action.replaceAll("-", " ")}`,
+    },
+  );
+
+  return selection?.profile;
+}
+
+async function promptForProfile(
+  existingProfile: AgentProfile | undefined,
+  otherProfileIds: readonly string[],
+): Promise<AgentProfile | undefined> {
+  const label = await vscode.window.showInputBox({
+    ignoreFocusOut: true,
+    prompt: existingProfile ? `Edit profile label for ${existingProfile.label}` : "Create a profile label",
+    placeHolder: "Team agent",
+    value: existingProfile?.label ?? "",
+    validateInput: (value) => value.trim().length > 0 ? null : "A label is required.",
+  });
+  if (!label) {
+    return undefined;
+  }
+
+  const id = await vscode.window.showInputBox({
+    ignoreFocusOut: true,
+    prompt: "Profile id",
+    placeHolder: "team-agent",
+    value: existingProfile?.id ?? slugifyProfileId(label),
+    validateInput: (value) => validateProfileId(value, otherProfileIds),
+  });
+  if (!id) {
+    return undefined;
+  }
+
+  const kind = await promptForProfileKind();
+  if (!kind) {
+    return undefined;
+  }
+
+  const command = await vscode.window.showInputBox({
+    ignoreFocusOut: true,
+    prompt: `Command used to launch ${label}`,
+    placeHolder: kind === "custom" ? "my-agent --interactive" : kind,
+    value: existingProfile?.command ?? kind,
+    validateInput: (value) => value.trim().length > 0 ? null : "A launch command is required.",
+  });
+  if (!command) {
+    return undefined;
+  }
+
+  const extraArgs = await vscode.window.showInputBox({
+    ignoreFocusOut: true,
+    prompt: `Extra arguments for ${label}`,
+    placeHolder: "--model fast",
+    value: existingProfile?.extraArgs ?? "",
+  });
+  if (extraArgs === undefined) {
+    return undefined;
+  }
+
+  const usesContext = await promptForContextBehavior();
+  if (usesContext === undefined) {
+    return undefined;
+  }
+
+  return {
+    builtIn: Boolean(getBuiltInAgentProfileById(id.trim())),
+    command: command.trim(),
+    extraArgs,
+    id: id.trim(),
+    kind,
+    label: label.trim(),
+    usesContext,
+  };
+}
+
+async function promptForProfileKind(): Promise<AgentKind | undefined> {
+  const selection = await vscode.window.showQuickPick([
+    { description: "Resume-aware Claude launcher", label: "Claude", value: "claude" },
+    { description: "GitHub Copilot CLI launcher", label: "Copilot", value: "copilot" },
+    { description: "Strands launcher", label: "Strands", value: "strands" },
+    { description: "Generic command without built-in session semantics", label: "Custom", value: "custom" },
+  ] as const, {
+    ignoreFocusOut: true,
+    placeHolder: "Choose the agent type",
+  });
+
+  return selection?.value;
+}
+
+async function promptForContextBehavior(): Promise<boolean | undefined> {
+  const selection = await vscode.window.showQuickPick([
+    { description: "Launch the command directly", label: "Do not send work item context", value: false },
+    { description: "Send the work item prompt after launch", label: "Send work item context after launch", value: true },
+  ] as const, {
+    ignoreFocusOut: true,
+    placeHolder: "Choose the context behavior",
+  });
+
+  return selection?.value;
+}
+
+function validateProfileId(value: string, existingIds: readonly string[]): string | null {
+  const normalized = value.trim();
+  if (!normalized) {
+    return "A profile id is required.";
+  }
+
+  if (!/^[a-z0-9-]+$/u.test(normalized)) {
+    return "Use lowercase letters, numbers, and hyphens only.";
+  }
+
+  if (existingIds.includes(normalized)) {
+    return "That profile id already exists.";
+  }
+
+  return null;
+}
+
+function slugifyProfileId(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    || "profile";
+}
+
+function getConfigurationTarget(): vscode.ConfigurationTarget {
+  return vscode.workspace.workspaceFolders?.length
+    ? vscode.ConfigurationTarget.Workspace
+    : vscode.ConfigurationTarget.Global;
 }

--- a/src/workTerminal/renderWorkTerminalHtml.ts
+++ b/src/workTerminal/renderWorkTerminalHtml.ts
@@ -1,11 +1,12 @@
 export interface WorkTerminalViewState {
   readonly agentProfiles: ReadonlyArray<{
+    readonly builtIn: boolean;
     readonly command: string;
     readonly id: string;
-    readonly kind: "claude" | "copilot";
+    readonly kind: "claude" | "copilot" | "custom" | "strands";
     readonly label: string;
     readonly resumeBehaviorLabel: string;
-    readonly status: "missing-command" | "ready";
+    readonly status: "invalid-configuration" | "missing-command" | "ready";
     readonly statusLabel: string;
     readonly usesContext: boolean;
   }>;
@@ -29,6 +30,10 @@ export interface WorkTerminalViewState {
     readonly label: string;
   }>;
   readonly latestWorkItemTitle: string | null;
+  readonly profileIssues: ReadonlyArray<{
+    readonly message: string;
+    readonly profileId: string | null;
+  }>;
   readonly selectedItemId: string | null;
   readonly recentlyClosedSessions: ReadonlyArray<{
     readonly closedAt: string;
@@ -37,7 +42,7 @@ export interface WorkTerminalViewState {
     readonly itemDescription: string | null;
     readonly itemId: string;
     readonly itemTitle: string;
-    readonly kind: "claude" | "copilot" | "shell";
+    readonly kind: "claude" | "copilot" | "custom" | "shell" | "strands";
     readonly label: string;
     readonly profileId: string | null;
     readonly profileLabel: string | null;
@@ -55,7 +60,7 @@ export interface WorkTerminalViewState {
     readonly itemDescription: string | null;
     readonly itemId: string;
     readonly itemTitle: string;
-    readonly kind: "claude" | "copilot" | "shell";
+    readonly kind: "claude" | "copilot" | "custom" | "shell" | "strands";
     readonly label: string;
     readonly profileId: string | null;
     readonly profileLabel: string | null;

--- a/test/agents/AgentLauncher.test.ts
+++ b/test/agents/AgentLauncher.test.ts
@@ -4,15 +4,14 @@ import {
   buildAgentLaunchPlan,
   getAgentProfileSummaries,
   getBuiltInAgentProfiles,
-  getNormalizedConfiguredCommand,
   splitConfiguredCommand,
 } from "../../src/agents";
 
 describe("AgentLauncher", () => {
   it("splits configured commands with quoted arguments", () => {
-    expect(splitConfiguredCommand('node "/tmp/My Tool/runner.js" --flag')).toEqual([
+    expect(splitConfiguredCommand('node "workspace/My Tool/runner.js" --flag')).toEqual([
       "node",
-      "/tmp/My Tool/runner.js",
+      "workspace/My Tool/runner.js",
       "--flag",
     ]);
   });
@@ -22,10 +21,12 @@ describe("AgentLauncher", () => {
     expect(profile).toBeDefined();
 
     const plan = buildAgentLaunchPlan({
-      configuredCommand: "claude",
-      configuredExtraArgs: "--dangerously-skip-permissions",
       contextPrompt: null,
-      profile: profile!,
+      profile: {
+        ...profile!,
+        command: "claude",
+        extraArgs: "--dangerously-skip-permissions",
+      },
     });
 
     expect(plan.executable).toBe("claude");
@@ -35,41 +36,57 @@ describe("AgentLauncher", () => {
     expect(plan.initialPrompt).toBeNull();
   });
 
-  it("builds a context launch plan that sends the prompt after launch", () => {
-    const profile = getBuiltInAgentProfiles().find((candidate) => candidate.id === "copilot-context");
+  it("builds a Strands context launch plan that sends the prompt after launch", () => {
+    const profile = getBuiltInAgentProfiles().find((candidate) => candidate.id === "strands-context");
     expect(profile).toBeDefined();
 
     const plan = buildAgentLaunchPlan({
-      configuredCommand: "copilot chat",
-      configuredExtraArgs: "--model gpt-5",
       contextPrompt: "Work item context",
-      profile: profile!,
+      profile: {
+        ...profile!,
+        command: "strands chat",
+        extraArgs: "--model fast",
+      },
     });
 
-    expect(plan.executable).toBe("copilot");
-    expect(plan.args).toEqual(["chat", "--model", "gpt-5"]);
+    expect(plan.executable).toBe("strands");
+    expect(plan.args).toEqual(["chat", "--model", "fast"]);
     expect(plan.initialPrompt).toBe("Work item context");
     expect(plan.sessionId).toBeNull();
   });
 
-  it("normalizes whitespace-only commands back to the default executable", () => {
-    expect(getNormalizedConfiguredCommand("   ", "copilot")).toBe("copilot");
+  it("marks multi-token launch commands as ready when the executable exists", () => {
+    const summaries = getAgentProfileSummaries([
+      {
+        builtIn: false,
+        command: `node ./node_modules/vitest/vitest.mjs`,
+        extraArgs: "run",
+        id: "team-agent",
+        kind: "custom",
+        label: "Team agent",
+        usesContext: false,
+      },
+    ]);
+
+    expect(summaries[0]).toEqual(expect.objectContaining({ status: "ready" }));
   });
 
-  it("marks multi-token launch commands as ready when the executable exists", () => {
-    const profile = getBuiltInAgentProfiles().find((candidate) => candidate.id === "copilot");
-    expect(profile).toBeDefined();
-
-    const summaries = getAgentProfileSummaries({
-      get<T>(section: string, defaultValue?: T): T {
-        if (section === profile!.commandConfigurationKey) {
-          return "node ./node_modules/vitest/vitest.mjs" as T;
-        }
-
-        return defaultValue as T;
+  it("surfaces invalid configuration when the command is blank", () => {
+    const summaries = getAgentProfileSummaries([
+      {
+        builtIn: false,
+        command: "   ",
+        extraArgs: "",
+        id: "broken",
+        kind: "custom",
+        label: "Broken",
+        usesContext: false,
       },
-    });
+    ]);
 
-    expect(summaries.find((summary) => summary.id === "copilot")?.status).toBe("ready");
+    expect(summaries[0]).toEqual(expect.objectContaining({
+      status: "invalid-configuration",
+      statusLabel: expect.stringContaining("Invalid configuration"),
+    }));
   });
 });

--- a/test/agents/AgentProfile.test.ts
+++ b/test/agents/AgentProfile.test.ts
@@ -2,23 +2,31 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildWorkItemContextPrompt,
-  getAgentProfileById,
+  getBuiltInAgentProfileById,
   getBuiltInAgentProfiles,
+  getResumeBehaviorLabel,
 } from "../../src/agents";
 
 describe("AgentProfile", () => {
-  it("exposes the built-in launch profiles", () => {
+  it("exposes the built-in launch profiles including Strands", () => {
     expect(getBuiltInAgentProfiles().map((profile) => profile.id)).toEqual([
       "claude",
       "claude-context",
       "copilot",
       "copilot-context",
+      "strands",
+      "strands-context",
     ]);
   });
 
-  it("looks up profiles by id", () => {
-    expect(getAgentProfileById("claude-context")?.usesContext).toBe(true);
-    expect(getAgentProfileById("missing-profile")).toBeNull();
+  it("looks up built-in profiles by id", () => {
+    expect(getBuiltInAgentProfileById("claude-context")?.usesContext).toBe(true);
+    expect(getBuiltInAgentProfileById("missing-profile")).toBeNull();
+  });
+
+  it("describes resume behavior for custom and built-in kinds", () => {
+    expect(getResumeBehaviorLabel({ kind: "custom", usesContext: false })).toContain("configured agent command");
+    expect(getResumeBehaviorLabel({ kind: "strands", usesContext: true })).toContain("sends work item context");
   });
 
   it("builds a work item context prompt with a description", () => {

--- a/test/agents/AgentProfileConfiguration.test.ts
+++ b/test/agents/AgentProfileConfiguration.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  loadAgentProfileCatalog,
+  serializeAgentProfiles,
+  type AgentProfile,
+} from "../../src/agents";
+
+describe("AgentProfileConfiguration", () => {
+  it("falls back to built-in profiles when the custom setting is unset", () => {
+    const catalog = loadAgentProfileCatalog({
+      get<T>(section: string, defaultValue?: T): T {
+        const values: Record<string, string | undefined> = {
+          claudeCommand: "claude-dev",
+          strandsCommand: "strands-dev",
+        };
+        return ((values[section] as T | undefined) ?? defaultValue) as T;
+      },
+    });
+
+    expect(catalog.issues).toEqual([]);
+    expect(catalog.profiles.find((profile) => profile.id === "claude")?.command).toBe("claude-dev");
+    expect(catalog.profiles.find((profile) => profile.id === "strands")?.command).toBe("strands-dev");
+  });
+
+  it("loads custom profiles in order and preserves built-in ids", () => {
+    const catalog = loadAgentProfileCatalog({
+      get<T>(section: string, defaultValue?: T): T {
+        if (section === "agentProfiles") {
+          return [
+            {
+              command: "claude --dangerous",
+              id: "claude",
+              kind: "claude",
+              label: "Claude override",
+              usesContext: true,
+            },
+            {
+              command: "team-agent",
+              extraArgs: "--fast",
+              id: "team-agent",
+              kind: "custom",
+              label: "Team agent",
+            },
+          ] as T;
+        }
+
+        return defaultValue as T;
+      },
+    });
+
+    expect(catalog.issues).toEqual([]);
+    expect(catalog.profiles.map((profile) => profile.id)).toEqual(["claude", "team-agent"]);
+    expect(catalog.profiles[0]?.builtIn).toBe(true);
+    expect(catalog.profiles[1]?.builtIn).toBe(false);
+  });
+
+  it("reports invalid profiles and skips duplicates", () => {
+    const catalog = loadAgentProfileCatalog({
+      get<T>(section: string, defaultValue?: T): T {
+        if (section === "agentProfiles") {
+          return [
+            { command: "", id: "broken", kind: "custom", label: "Broken" },
+            { command: "custom", id: "dup", kind: "custom", label: "First" },
+            { command: "custom", id: "dup", kind: "custom", label: "Second" },
+          ] as T;
+        }
+
+        return defaultValue as T;
+      },
+    });
+
+    expect(catalog.profiles.map((profile) => profile.id)).toEqual(["dup"]);
+    expect(catalog.issues).toEqual([
+      expect.objectContaining({ message: expect.stringContaining("must include a non-empty command"), profileId: "broken" }),
+      expect.objectContaining({ message: expect.stringContaining("duplicated"), profileId: "dup" }),
+    ]);
+  });
+
+  it("serializes profiles for settings persistence", () => {
+    const profiles: readonly AgentProfile[] = [
+      {
+        builtIn: false,
+        command: "custom-agent",
+        extraArgs: "--fast",
+        id: "team-agent",
+        kind: "custom",
+        label: "Team agent",
+        usesContext: true,
+      },
+    ];
+
+    expect(serializeAgentProfiles(profiles)).toEqual([
+      {
+        command: "custom-agent",
+        extraArgs: "--fast",
+        id: "team-agent",
+        kind: "custom",
+        label: "Team agent",
+        usesContext: true,
+      },
+    ]);
+  });
+});

--- a/test/renderWorkTerminalHtml.test.ts
+++ b/test/renderWorkTerminalHtml.test.ts
@@ -11,6 +11,7 @@ describe("renderWorkTerminalHtml", () => {
       state: {
         agentProfiles: [
           {
+            builtIn: true,
             command: "claude",
             id: "claude",
             kind: "claude",
@@ -49,6 +50,7 @@ describe("renderWorkTerminalHtml", () => {
           { count: 0, id: "todo", label: "To Do" },
         ],
         latestWorkItemTitle: "Demo task",
+        profileIssues: [],
         recentlyClosedSessions: [],
         selectedItemId: "123e4567-e89b-12d3-a456-426614174000",
         status: "Ready",
@@ -124,6 +126,7 @@ describe("renderWorkTerminalHtml", () => {
         },
         columnSummaries: [{ count: 1, id: "active", label: "Active" }],
         latestWorkItemTitle: "Demo\u2029task",
+        profileIssues: [],
         recentlyClosedSessions: [],
         selectedItemId: "123e4567-e89b-12d3-a456-426614174000",
         status: "Ready",

--- a/test/terminals/TerminalSessionPersistence.test.ts
+++ b/test/terminals/TerminalSessionPersistence.test.ts
@@ -293,6 +293,35 @@ describe("TerminalSessionPersistence", () => {
     expect(files.some((file) => file.startsWith("terminal-sessions.v1.json.corrupt-"))).toBe(true);
   });
 
+  it("trims persisted profile ids when reloading sessions", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "work-terminal-session-persistence-"));
+    tempDirectories.push(workspaceRoot);
+
+    const persistence = new TerminalSessionPersistence(workspaceRoot);
+    const snapshotPath = persistence.getStoragePath();
+
+    await mkdir(dirname(snapshotPath!), { recursive: true });
+    await writeFile(snapshotPath!, JSON.stringify({
+      recentlyClosedSessions: [],
+      sessions: [
+        createPersistedSession({
+          id: "session-1",
+          kind: "claude",
+          profileId: " claude-context ",
+          profileLabel: "Claude (ctx)",
+        }),
+      ],
+      version: 1,
+    }, null, 2), "utf8");
+
+    await expect(persistence.loadSessions()).resolves.toEqual([
+      expect.objectContaining({
+        id: "session-1",
+        profileId: "claude-context",
+      }),
+    ]);
+  });
+
   it("backs up snapshots with invalid recently closed timestamps before loading them", async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), "work-terminal-session-persistence-"));
     tempDirectories.push(workspaceRoot);

--- a/test/terminals/TerminalSessionStore.test.ts
+++ b/test/terminals/TerminalSessionStore.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-type ConfigurationValues = Record<string, string>;
+type ConfigurationValues = Record<string, unknown>;
 
 interface MockTerminal {
   dispose: ReturnType<typeof vi.fn>;
@@ -17,10 +17,13 @@ interface MockTerminal {
 }
 
 const configurationValues: ConfigurationValues = {
+  agentProfiles: undefined,
   claudeCommand: "claude",
   claudeExtraArgs: "",
   copilotCommand: "copilot",
   copilotExtraArgs: "",
+  strandsCommand: "strands",
+  strandsExtraArgs: "",
 };
 
 const createdTerminals: MockTerminal[] = [];
@@ -119,10 +122,13 @@ describe("TerminalSessionStore", () => {
     createdTerminalOptions.length = 0;
     closeListeners.length = 0;
     terminalStateListeners.length = 0;
+    configurationValues.agentProfiles = undefined;
     configurationValues.claudeCommand = "claude";
     configurationValues.claudeExtraArgs = "";
     configurationValues.copilotCommand = "copilot";
     configurationValues.copilotExtraArgs = "";
+    configurationValues.strandsCommand = "strands";
+    configurationValues.strandsExtraArgs = "";
     vi.useFakeTimers();
   });
 
@@ -230,6 +236,62 @@ describe("TerminalSessionStore", () => {
 
     expect(result.session).toBeNull();
     expect(result.error).toContain("Claude is not available");
+
+    store.dispose();
+  });
+
+  it("launches a custom agent profile from settings", async () => {
+    configurationValues.agentProfiles = [
+      {
+        command: process.execPath,
+        extraArgs: "--version",
+        id: "team-agent",
+        kind: "custom",
+        label: "Team agent",
+        usesContext: true,
+      },
+    ];
+
+    const { TerminalSessionStore } = await import("../../src/terminals");
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "work-terminal-terminal-store-"));
+    tempDirectories.push(workspaceRoot);
+    const store = new TerminalSessionStore(workspaceRoot);
+
+    const result = await store.createAgentSession({
+      cwd: "/workspace",
+      itemDescription: "Use the shared context",
+      itemId: "item-1",
+      itemTitle: "Investigate regression",
+      profileId: "team-agent",
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.session).toEqual(expect.objectContaining({
+      kind: "custom",
+      profileId: "team-agent",
+      profileLabel: "Team agent",
+      resumeSessionId: null,
+    }));
+    expect(createdTerminalOptions[0]).toEqual(expect.objectContaining({
+      shellArgs: ["--version"],
+      shellPath: process.execPath,
+    }));
+
+    await vi.advanceTimersByTimeAsync(250);
+    expect(createdTerminals[0].sendText).toHaveBeenCalledWith(expect.stringContaining("Work item context:"), true);
+
+    store.dispose();
+  });
+
+  it("includes Strands in the available profile summaries", async () => {
+    configurationValues.strandsCommand = process.execPath;
+
+    const { TerminalSessionStore } = await import("../../src/terminals");
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "work-terminal-terminal-store-"));
+    tempDirectories.push(workspaceRoot);
+    const store = new TerminalSessionStore(workspaceRoot);
+
+    expect(store.getSummary().agentProfiles.some((profile) => profile.id === "strands" && profile.status === "ready")).toBe(true);
 
     store.dispose();
   });


### PR DESCRIPTION
## Summary
- add built-in Strands profiles plus configurable custom agent profile catalog loading and serialization
- add a Manage Profiles flow for create, edit, delete, reset, and reordering from the extension
- surface profile diagnostics in the board UI and extend tests plus docs for the new profile model

## Testing
- pnpm check
- pnpm build
- pnpm package