### PR TITLE
Add work item adapter architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,18 +7,21 @@ Contributor guide for the VS Code extension port of Work Terminal.
 The codebase is split across three main areas:
 
 ```text
-src/
-  extension.ts                  # Extension entry point
-  agents/
-    AgentLauncher.ts            # Config parsing, executable resolution, launch plans
-    AgentProfile.ts             # Built-in Claude/Copilot profiles and context prompts
-  terminals/
-    TerminalSessionStore.ts     # VS Code terminal creation and in-memory session tracking
-  workItems/
-    WorkItemStore.ts            # Workspace-local JSON persistence with atomic writes
-    createWorkItem.ts           # Work item creation and normalization
-    constants.ts                # State, column, source, and priority enums
-    snapshot.ts                 # Snapshot validation and normalization helpers
+  src/
+    extension.ts                  # Extension entry point
+    agents/
+      AgentLauncher.ts            # Config parsing, executable resolution, launch plans
+      AgentProfile.ts             # Built-in Claude/Copilot/Strands profiles
+    terminals/
+      TerminalSessionStore.ts     # VS Code terminal creation, in-memory session tracking, adapter-backed context prompts
+    workItems/
+      adapter.ts                  # Parser, mover, renderer, prompt, and config interfaces for work-item sources
+      builtInJsonAdapter.ts       # Default workspace-local JSON adapter implementation
+      WorkItemStore.ts            # Adapter-driven persistence orchestration with atomic writes
+      board.ts                    # Board-facing card, column, and summary types
+      createWorkItem.ts           # Work item creation and normalization
+      constants.ts                # State, column, source, and priority enums
+      snapshot.ts                 # Snapshot validation and normalization helpers
   workTerminal/
     WorkTerminalViewProvider.ts # Webview orchestration and message handling
     renderWorkTerminalHtml.ts   # HTML shell, CSP, bootstrap state

--- a/README.md
+++ b/README.md
@@ -133,12 +133,16 @@ The extension-host side owns VS Code API integration, persistence, terminal life
 
 - `src/extension.ts` - activates the extension, wires commands, stores, and the webview provider
 - `src/workTerminal/WorkTerminalViewProvider.ts` - owns the webview bridge and user action handling
-- `src/workItems/WorkItemStore.ts` - loads and saves `.work-terminal/work-items.v1.json`, with a write queue and corrupt snapshot recovery
+- `src/workItems/adapter.ts` - defines the parser, mover, renderer, prompt-builder, and config interfaces for work-item sources
+- `src/workItems/builtInJsonAdapter.ts` - default workspace-local JSON adapter implementing the work-item source boundary
+- `src/workItems/WorkItemStore.ts` - framework-facing store that delegates parsing, rendering, and mutations to the configured adapter while persisting the current workspace-local snapshot
 - `src/terminals/TerminalSessionStore.ts` - creates shell and agent terminals, persists recoverable session metadata, restores saved sessions, and refocuses terminals
 - `src/terminals/TerminalSessionPersistence.ts` - loads and saves `.work-terminal/terminal-sessions.v1.json`, with atomic writes and corrupt snapshot recovery
 - `src/agents/AgentLauncher.ts` - resolves configured commands, splits quoted arguments, validates executables, and builds launch plans
-- `src/agents/AgentProfile.ts` - defines the built-in Claude, Copilot, and Strands defaults plus the work-item context prompt format
+- `src/agents/AgentProfile.ts` - defines the built-in Claude, Copilot, and Strands defaults
 - `src/agents/AgentProfileConfiguration.ts` - loads profile settings, validates custom profiles, and serializes profile edits
+
+The built-in adapter keeps the current `.work-terminal/work-items.v1.json` behavior as the default source. The extension-host framework now depends on adapter interfaces for snapshot parsing, board rendering, selected-item detail resolution, column movement, context prompting, and source configuration so future task-file-backed adapters can slot in without reworking the board or terminal layers.
 
 ### Webview
 

--- a/src/agents/AgentProfile.ts
+++ b/src/agents/AgentProfile.ts
@@ -121,18 +121,3 @@ export function getResumeBehaviorLabel(profile: Pick<AgentProfile, "kind" | "use
         : "Launches the configured agent command.";
   }
 }
-
-export function buildWorkItemContextPrompt(itemTitle: string, itemDescription: string | null): string {
-  const lines = [
-    "Work item context:",
-    `- Title: ${itemTitle}`,
-  ];
-
-  if (itemDescription?.trim()) {
-    lines.push(`- Description: ${itemDescription.trim()}`);
-  }
-
-  lines.push("", "Start by confirming the task understanding and proposing the next concrete step.");
-
-  return lines.join("\n");
-}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,6 +1,5 @@
 export {
   AGENT_KINDS,
-  buildWorkItemContextPrompt,
   getBuiltInAgentProfileById,
   getBuiltInAgentProfiles,
   getResumeBehaviorLabel,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,12 +2,13 @@ import { TerminalSessionStore } from "./terminals";
 import * as vscode from "vscode";
 
 import { WorkTerminalViewProvider } from "./workTerminal/WorkTerminalViewProvider";
-import { WorkItemStore } from "./workItems";
+import { createBuiltInJsonWorkItemSourceAdapter, WorkItemStore } from "./workItems";
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const workspaceRootPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? null;
-  const store = new WorkItemStore(workspaceRootPath);
-  const terminalStore = new TerminalSessionStore(workspaceRootPath);
+  const workItemAdapter = createBuiltInJsonWorkItemSourceAdapter();
+  const store = new WorkItemStore(workspaceRootPath, workItemAdapter);
+  const terminalStore = new TerminalSessionStore(workspaceRootPath, workItemAdapter.promptBuilder);
   const recovery = await terminalStore.restorePersistedSessions();
   const provider = new WorkTerminalViewProvider(
     context.extensionUri,

--- a/src/terminals/TerminalSessionStore.ts
+++ b/src/terminals/TerminalSessionStore.ts
@@ -2,13 +2,16 @@ import * as vscode from "vscode";
 
 import {
   buildAgentLaunchPlan,
-  buildWorkItemContextPrompt,
   getAgentProfileSummaries,
   loadAgentProfileCatalog,
   type AgentProfileId,
   type AgentProfileIssue,
   type AgentProfileSummary,
 } from "../agents";
+import {
+  createBuiltInJsonWorkItemSourceAdapter,
+  type WorkItemSourcePromptBuilder,
+} from "../workItems";
 import {
   type RecentlyClosedTerminalSession,
   TerminalSessionPersistence,
@@ -60,14 +63,19 @@ export class TerminalSessionStore implements vscode.Disposable {
   private readonly monitorInterval: ReturnType<typeof setInterval>;
   private readonly pendingInitialPromptTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly persistence: TerminalSessionPersistence;
+  private readonly promptBuilder: WorkItemSourcePromptBuilder;
   private refreshSessionTrackingPromise: Promise<void> | null = null;
   private recentlyClosedSessions: readonly RecentlyClosedTerminalSession[] = [];
   private readonly sessionsChangedEmitter = new vscode.EventEmitter<void>();
   private readonly sessionsById = new Map<string, StoredTerminalSession>();
   private readonly terminalStateDisposable: vscode.Disposable;
 
-  public constructor(workspaceRootPath: string | null) {
+  public constructor(
+    workspaceRootPath: string | null,
+    promptBuilder: WorkItemSourcePromptBuilder = createBuiltInJsonWorkItemSourceAdapter().promptBuilder,
+  ) {
     this.persistence = new TerminalSessionPersistence(workspaceRootPath);
+    this.promptBuilder = promptBuilder;
     this.closeDisposable = vscode.window.onDidCloseTerminal((terminal) => {
       void this.handleClosedTerminal(terminal);
     });
@@ -196,7 +204,10 @@ export class TerminalSessionStore implements vscode.Disposable {
     }
     const contextPrompt = createOptions.skipInitialPrompt
       ? null
-      : buildWorkItemContextPrompt(options.itemTitle, options.itemDescription);
+      : this.promptBuilder.buildContextPrompt({
+        description: options.itemDescription,
+        title: options.itemTitle,
+      });
     let launchPlan;
     try {
       launchPlan = buildAgentLaunchPlan({

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -47,6 +47,26 @@ interface WorkTerminalViewState {
     readonly message: string;
     readonly profileId: string | null;
   }>;
+  readonly selectedItem: {
+    readonly blockerReason: string | null;
+    readonly column: string;
+    readonly completedAt: string | null;
+    readonly createdAt: string;
+    readonly description: string | null;
+    readonly id: string;
+    readonly isBlocked: boolean;
+    readonly priorityDeadline: string | null;
+    readonly priorityLevel: string;
+    readonly priorityScore: number;
+    readonly sourceCapturedAt: string | null;
+    readonly sourceExternalId: string | null;
+    readonly sourceKind: string;
+    readonly sourcePath: string | null;
+    readonly sourceUrl: string | null;
+    readonly state: string;
+    readonly title: string;
+    readonly updatedAt: string;
+  } | null;
   readonly selectedItemId: string | null;
   readonly recentlyClosedSessions: ReadonlyArray<{
     readonly closedAt: string;
@@ -722,21 +742,13 @@ function render(nextState: WorkTerminalViewState): void {
   restoreFilterInputSnapshot(filterInputSnapshot);
 }
 
-function getSelectedItem(nextState: WorkTerminalViewState): WorkTerminalViewState["boardColumns"][number]["items"][number] | null {
-  return (
-    nextState.boardColumns.flatMap((column) => column.items).find((item) => item.id === nextState.selectedItemId) ??
-    nextState.boardColumns.flatMap((column) => column.items)[0] ??
-    null
-  );
-}
-
 function getActionableSelectedItem(
   nextState: WorkTerminalViewState,
   query: string,
   visibleItems: WorkTerminalViewState["boardColumns"][number]["items"] | null = null,
 ): WorkTerminalViewState["boardColumns"][number]["items"][number] | null {
   if (query.trim().length === 0) {
-    return getSelectedItem(nextState);
+    return nextState.selectedItem;
   }
 
   const actionableItems = visibleItems ?? getVisibleBoardColumns(nextState, query).flatMap((column) => column.items);
@@ -778,6 +790,7 @@ function createFallbackState(): WorkTerminalViewState {
     latestWorkItemTitle: null,
     profileIssues: [],
     recentlyClosedSessions: [],
+    selectedItem: null,
     selectedItemId: null,
     status: "Scaffold ready",
     storagePath: null,

--- a/src/workItems/WorkItemStore.ts
+++ b/src/workItems/WorkItemStore.ts
@@ -1,89 +1,40 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
 
-import {
-  createEmptyPersistedWorkItemSnapshot,
-  createWorkItem,
-  normalizeOptionalString,
-  normalizePriorityLevel,
-  normalizePriorityScore,
-  normalizeSourceKind,
-  normalizeTimestamp,
-  normalizePersistedWorkItemSnapshot,
-  WORK_ITEM_COLUMNS,
-  WORK_ITEM_STATE_TO_COLUMN,
-  type WorkItem,
-  type CreateWorkItemInput,
-  type PersistedWorkItemSnapshot,
-  type SplitWorkItemInput,
-  type WorkItemColumn,
-  type WorkItemState,
-  type UpdateWorkItemInput,
-} from "./index";
-
-const STORAGE_DIRECTORY_NAME = ".work-terminal";
-const STORAGE_FILE_NAME = "work-items.v1.json";
-
-const COLUMN_LABELS: Record<WorkItemColumn, string> = {
-  priority: "Priority",
-  todo: "To Do",
-  active: "Active",
-  done: "Done",
-};
-
-export interface WorkItemColumnSummary {
-  readonly id: WorkItemColumn;
-  readonly label: string;
-  readonly count: number;
-}
-
-export interface WorkItemBoardCard {
-  readonly blockerReason: string | null;
-  readonly column: WorkItemColumn;
-  readonly completedAt: string | null;
-  readonly createdAt: string;
-  readonly description: string | null;
-  readonly id: string;
-  readonly isBlocked: boolean;
-  readonly priorityDeadline: string | null;
-  readonly priorityLevel: string;
-  readonly priorityScore: number;
-  readonly sourceCapturedAt: string | null;
-  readonly sourceExternalId: string | null;
-  readonly sourceKind: string;
-  readonly sourcePath: string | null;
-  readonly sourceUrl: string | null;
-  readonly state: WorkItemState;
-  readonly title: string;
-  readonly updatedAt: string;
-}
-
-export interface WorkItemBoardColumn {
-  readonly id: WorkItemColumn;
-  readonly items: readonly WorkItemBoardCard[];
-  readonly label: string;
-}
-
-export interface WorkItemStoreSummary {
-  readonly boardColumns: readonly WorkItemBoardColumn[];
-  readonly collapsedColumns: Record<WorkItemColumn, boolean>;
-  readonly columnSummaries: readonly WorkItemColumnSummary[];
-  readonly latestWorkItemTitle: string | null;
-  readonly storagePath: string | null;
-  readonly totalCount: number;
-}
+import type { WorkItemColumn } from "./constants";
+import type { WorkItemSourceAdapter } from "./adapter";
+import type { WorkItemColumnDefinition, WorkItemStoreSummary } from "./board";
+import { createBuiltInJsonWorkItemSourceAdapter } from "./builtInJsonAdapter";
+import type {
+  CreateWorkItemInput,
+  PersistedWorkItemSnapshot,
+  SplitWorkItemInput,
+  UpdateWorkItemInput,
+  WorkItem,
+} from "./types";
 
 export class WorkItemStore {
   private writeQueue: Promise<void> = Promise.resolve();
 
-  public constructor(private readonly workspaceRootPath: string | null) {}
+  public constructor(
+    private readonly workspaceRootPath: string | null,
+    private readonly adapter: WorkItemSourceAdapter = createBuiltInJsonWorkItemSourceAdapter(),
+  ) {}
 
   public getStoragePath(): string | null {
     if (!this.workspaceRootPath) {
       return null;
     }
 
-    return join(this.workspaceRootPath, STORAGE_DIRECTORY_NAME, STORAGE_FILE_NAME);
+    return this.adapter.config.getStoragePath(this.workspaceRootPath);
+  }
+
+  public getColumnDefinitions(): readonly WorkItemColumnDefinition[] {
+    return this.adapter.config.getColumnDefinitions();
+  }
+
+  public getColumnLabel(column: WorkItemColumn): string {
+    return this.getColumnDefinitions().find((definition) => definition.id === column)?.label ?? column;
   }
 
   public async createWorkItem(input: CreateWorkItemInput): Promise<WorkItem | null> {
@@ -95,22 +46,9 @@ export class WorkItemStore {
 
     return this.withWriteLock(async () => {
       const snapshot = await this.loadSnapshotForWrite();
-      const item = createWorkItem(input);
-      const nextSnapshot: PersistedWorkItemSnapshot = {
-        ...snapshot,
-        items: {
-          ...snapshot.items,
-          [item.id]: item,
-        },
-        itemOrderByColumn: {
-          ...snapshot.itemOrderByColumn,
-          [item.column]: [item.id, ...snapshot.itemOrderByColumn[item.column].filter((id) => id !== item.id)],
-        },
-      };
-
-      await this.saveSnapshot(nextSnapshot);
-
-      return item;
+      const result = this.adapter.mover.createItem(snapshot, input);
+      await this.saveSnapshot(result.snapshot);
+      return result.item;
     });
   }
 
@@ -119,46 +57,19 @@ export class WorkItemStore {
     return snapshot.items[itemId] ?? null;
   }
 
-  public async getSummary(): Promise<WorkItemStoreSummary> {
+  public async getSummary(requestedSelectedItemId: string | null = null): Promise<WorkItemStoreSummary> {
     const snapshot = await this.loadSnapshotForRead();
     const items = Object.values(snapshot.items);
     const latest = [...items].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0];
+    const selectionState = this.adapter.renderer.resolveSelectionState(snapshot, requestedSelectedItemId);
 
     return {
-      boardColumns: WORK_ITEM_COLUMNS.map((column) => ({
-        id: column,
-        items: snapshot.itemOrderByColumn[column]
-          .map((id) => snapshot.items[id])
-          .filter((item): item is WorkItem => Boolean(item))
-          .map((item) => ({
-            blockerReason: item.priority.blockerReason,
-            column: item.column,
-            completedAt: item.completedAt,
-            createdAt: item.createdAt,
-            description: item.description,
-            id: item.id,
-            isBlocked: item.priority.isBlocked,
-            priorityDeadline: item.priority.deadline,
-            priorityLevel: item.priority.level,
-            priorityScore: item.priority.score,
-            sourceCapturedAt: item.source.capturedAt,
-            sourceExternalId: item.source.externalId,
-            sourceKind: item.source.kind,
-            sourcePath: item.source.path,
-            sourceUrl: item.source.url,
-            state: item.state,
-            title: item.title,
-            updatedAt: item.updatedAt,
-          })),
-        label: COLUMN_LABELS[column],
-      })),
+      boardColumns: this.adapter.renderer.renderBoardColumns(snapshot),
       collapsedColumns: { ...snapshot.collapsedColumns },
-      columnSummaries: WORK_ITEM_COLUMNS.map((column) => ({
-        id: column,
-        label: COLUMN_LABELS[column],
-        count: snapshot.itemOrderByColumn[column].length,
-      })),
+      columnSummaries: this.adapter.renderer.renderColumnSummaries(snapshot),
       latestWorkItemTitle: latest?.title ?? null,
+      selectedItem: selectionState.selectedItem,
+      selectedItemId: selectionState.selectedItemId,
       storagePath: this.getStoragePath(),
       totalCount: items.length,
     };
@@ -172,62 +83,13 @@ export class WorkItemStore {
 
     return this.withWriteLock(async () => {
       const snapshot = await this.loadSnapshotForWrite();
-      const item = snapshot.items[itemId];
-      if (!item) {
+      const result = this.adapter.mover.updateItem(snapshot, itemId, updates);
+      if (!result.item) {
         return null;
       }
 
-      const timestamp = normalizeTimestamp(updates.now, new Date().toISOString());
-      const nextState = updates.state ? normalizeState(updates.state) : item.state;
-      const nextColumn = WORK_ITEM_STATE_TO_COLUMN[nextState];
-      const requestedBlocked = updates.priority?.isBlocked;
-      const nextBlocked = requestedBlocked == null ? item.priority.isBlocked : Boolean(requestedBlocked);
-      const nextItem: WorkItem = {
-        ...item,
-        title: updates.title == null ? item.title : normalizeOptionalString(updates.title) ?? item.title,
-        description: updates.description === undefined ? item.description : normalizeOptionalString(updates.description),
-        state: nextState,
-        column: nextColumn,
-        source: {
-          kind: updates.source?.kind == null ? item.source.kind : normalizeSourceKind(updates.source.kind),
-          externalId: updates.source?.externalId === undefined
-            ? item.source.externalId
-            : normalizeOptionalString(updates.source.externalId),
-          url: updates.source?.url === undefined
-            ? item.source.url
-            : normalizeOptionalString(updates.source.url),
-          path: updates.source?.path === undefined
-            ? item.source.path
-            : normalizeOptionalString(updates.source.path),
-          fingerprint: updates.source?.fingerprint === undefined
-            ? item.source.fingerprint
-            : normalizeOptionalString(updates.source.fingerprint),
-          capturedAt: updates.source?.capturedAt === undefined
-            ? item.source.capturedAt
-            : normalizeOptionalString(updates.source.capturedAt),
-        },
-        priority: {
-          level: updates.priority?.level == null ? item.priority.level : normalizePriorityLevel(updates.priority.level),
-          score: updates.priority?.score == null ? item.priority.score : normalizePriorityScore(updates.priority.score),
-          deadline: updates.priority?.deadline === undefined
-            ? item.priority.deadline
-            : normalizeOptionalString(updates.priority.deadline),
-          isBlocked: nextBlocked,
-          blockerReason: nextBlocked
-            ? updates.priority?.blockerReason === undefined
-              ? item.priority.blockerReason
-              : normalizeOptionalString(updates.priority.blockerReason)
-            : null,
-        },
-        updatedAt: timestamp,
-        completedAt: nextColumn === "done"
-          ? item.completedAt ?? timestamp
-          : null,
-      };
-
-      const nextSnapshot = moveItemWithinSnapshot(snapshot, nextItem, timestamp);
-      await this.saveSnapshot(nextSnapshot);
-      return nextItem;
+      await this.saveSnapshot(result.snapshot);
+      return result.item;
     });
   }
 
@@ -244,37 +106,12 @@ export class WorkItemStore {
 
     return this.withWriteLock(async () => {
       const snapshot = await this.loadSnapshotForWrite();
-      const item = snapshot.items[itemId];
-      if (!item || item.column !== fromColumn) {
+      const result = this.adapter.mover.reorderItems(snapshot, itemId, fromColumn, toColumn, targetIndex);
+      if (!result.reordered) {
         return false;
       }
 
-      const nextState = fromColumn === toColumn ? item.state : getStateForColumn(toColumn);
-      const normalizedIndex = Math.max(0, Math.min(targetIndex, snapshot.itemOrderByColumn[toColumn].length));
-      const nextItemOrderByColumn = Object.fromEntries(
-        WORK_ITEM_COLUMNS.map((column) => [column, snapshot.itemOrderByColumn[column].filter((id) => id !== itemId)]),
-      ) as Record<WorkItemColumn, string[]>;
-
-      nextItemOrderByColumn[toColumn].splice(normalizedIndex, 0, itemId);
-
-      const timestamp = new Date().toISOString();
-      const nextItem: WorkItem = {
-        ...item,
-        column: toColumn,
-        state: nextState,
-        updatedAt: timestamp,
-        completedAt: toColumn === "done" ? item.completedAt ?? timestamp : null,
-      };
-
-      await this.saveSnapshot({
-        ...snapshot,
-        items: {
-          ...snapshot.items,
-          [itemId]: nextItem,
-        },
-        itemOrderByColumn: nextItemOrderByColumn,
-      });
-
+      await this.saveSnapshot(result.snapshot);
       return true;
     });
   }
@@ -291,26 +128,13 @@ export class WorkItemStore {
 
     return this.withWriteLock(async () => {
       const snapshot = await this.loadSnapshotForWrite();
-      const item = snapshot.items[itemId];
-      if (!item) {
+      const result = this.adapter.mover.moveItemToColumn(snapshot, itemId, toColumn, targetIndex);
+      if (!result.item) {
         return null;
       }
 
-      const normalizedIndex = Math.max(0, Math.min(targetIndex, snapshot.itemOrderByColumn[toColumn].length));
-      const timestamp = new Date().toISOString();
-      const nextState = item.column === toColumn ? item.state : getStateForColumn(toColumn);
-      const nextItem: WorkItem = {
-        ...item,
-        column: toColumn,
-        state: nextState,
-        updatedAt: timestamp,
-        completedAt: toColumn === "done"
-          ? item.completedAt ?? timestamp
-          : null,
-      };
-      const nextSnapshot = moveItemWithinSnapshot(snapshot, nextItem, timestamp, normalizedIndex);
-      await this.saveSnapshot(nextSnapshot);
-      return nextItem;
+      await this.saveSnapshot(result.snapshot);
+      return result.item;
     });
   }
 
@@ -322,22 +146,12 @@ export class WorkItemStore {
 
     return this.withWriteLock(async () => {
       const snapshot = await this.loadSnapshotForWrite();
-      if (!snapshot.items[itemId]) {
+      const result = this.adapter.mover.deleteItem(snapshot, itemId);
+      if (!result.deleted) {
         return false;
       }
 
-      const nextItems = { ...snapshot.items };
-      delete nextItems[itemId];
-
-      const nextSnapshot: PersistedWorkItemSnapshot = {
-        ...snapshot,
-        items: nextItems,
-        itemOrderByColumn: Object.fromEntries(
-          WORK_ITEM_COLUMNS.map((column) => [column, snapshot.itemOrderByColumn[column].filter((id) => id !== itemId)]),
-        ) as Record<WorkItemColumn, string[]>,
-      };
-
-      await this.saveSnapshot(nextSnapshot);
+      await this.saveSnapshot(result.snapshot);
       return true;
     });
   }
@@ -350,42 +164,13 @@ export class WorkItemStore {
 
     return this.withWriteLock(async () => {
       const snapshot = await this.loadSnapshotForWrite();
-      const item = snapshot.items[itemId];
-      if (!item) {
+      const result = this.adapter.mover.splitItem(snapshot, itemId, input);
+      if (!result.item) {
         return null;
       }
 
-      const fallbackState = item.column === "done" ? "todo" : item.state;
-      const nextDescription = normalizeOptionalString(input.description) ?? buildSplitDescription(item);
-      const nextItem = createWorkItem({
-        title: input.title,
-        description: nextDescription,
-        state: input.state ?? fallbackState,
-        source: { ...item.source },
-        priority: { ...item.priority },
-        now: input.now,
-      });
-      const nextColumn = nextItem.column;
-      const existingOrder = snapshot.itemOrderByColumn[nextColumn].filter((id) => id !== nextItem.id);
-      const parentIndex = nextColumn === item.column ? existingOrder.indexOf(item.id) : -1;
-      const insertionIndex = parentIndex >= 0 ? parentIndex + 1 : 0;
-      const nextOrder = [...existingOrder];
-      nextOrder.splice(insertionIndex, 0, nextItem.id);
-
-      const nextSnapshot: PersistedWorkItemSnapshot = {
-        ...snapshot,
-        items: {
-          ...snapshot.items,
-          [nextItem.id]: nextItem,
-        },
-        itemOrderByColumn: {
-          ...snapshot.itemOrderByColumn,
-          [nextColumn]: nextOrder,
-        },
-      };
-
-      await this.saveSnapshot(nextSnapshot);
-      return nextItem;
+      await this.saveSnapshot(result.snapshot);
+      return result.item;
     });
   }
 
@@ -397,13 +182,7 @@ export class WorkItemStore {
 
     return this.withWriteLock(async () => {
       const snapshot = await this.loadSnapshotForWrite();
-      await this.saveSnapshot({
-        ...snapshot,
-        collapsedColumns: {
-          ...snapshot.collapsedColumns,
-          [column]: !snapshot.collapsedColumns[column],
-        },
-      });
+      await this.saveSnapshot(this.adapter.mover.toggleColumnCollapsed(snapshot, column));
       return true;
     });
   }
@@ -412,14 +191,14 @@ export class WorkItemStore {
     const storagePath = this.getStoragePath();
 
     if (!storagePath) {
-      return createEmptyPersistedWorkItemSnapshot();
+      return this.adapter.parser.createEmptySnapshot();
     }
 
     const content = await readFile(storagePath, "utf8");
 
     try {
       const parsed = JSON.parse(content) as unknown;
-      return normalizePersistedWorkItemSnapshot(parsed);
+      return this.adapter.parser.parseSnapshot(parsed);
     } catch (error) {
       throw new CorruptSnapshotError(storagePath, error);
     }
@@ -430,7 +209,7 @@ export class WorkItemStore {
       return await this.loadSnapshot();
     } catch (error) {
       if (isMissingFileError(error) || error instanceof CorruptSnapshotError) {
-        return createEmptyPersistedWorkItemSnapshot();
+        return this.adapter.parser.createEmptySnapshot();
       }
 
       throw error;
@@ -441,7 +220,7 @@ export class WorkItemStore {
     const storagePath = this.getStoragePath();
 
     if (!storagePath) {
-      return createEmptyPersistedWorkItemSnapshot();
+      return this.adapter.parser.createEmptySnapshot();
     }
 
     try {
@@ -452,14 +231,14 @@ export class WorkItemStore {
           `[work-terminal] Snapshot at ${error.storagePath} was corrupt. Backing it up and resetting the store.`,
         );
         await this.backupCorruptSnapshot(error.storagePath);
-        return createEmptyPersistedWorkItemSnapshot();
+        return this.adapter.parser.createEmptySnapshot();
       }
 
       if (!isMissingFileError(error)) {
         throw error;
       }
 
-      return createEmptyPersistedWorkItemSnapshot();
+      return this.adapter.parser.createEmptySnapshot();
     }
   }
 
@@ -498,61 +277,23 @@ export class WorkItemStore {
   }
 }
 
-function getStateForColumn(column: WorkItemColumn): WorkItem["state"] {
-  switch (column) {
-    case "priority":
-      return "priority";
-    case "todo":
-      return "todo";
-    case "active":
-      return "active";
-    case "done":
-      return "done";
-  }
-}
-
-function normalizeState(state: WorkItemState): WorkItemState {
-  return state === "priority" ||
-    state === "todo" ||
-    state === "active" ||
-    state === "done" ||
-    state === "abandoned"
-    ? state
-    : "todo";
-}
-
-function moveItemWithinSnapshot(
-  snapshot: PersistedWorkItemSnapshot,
-  nextItem: WorkItem,
-  timestamp: string,
-  targetIndex?: number,
-): PersistedWorkItemSnapshot {
-  const previousIndex = snapshot.itemOrderByColumn[nextItem.column].indexOf(nextItem.id);
-  const nextItemOrderByColumn = Object.fromEntries(
-    WORK_ITEM_COLUMNS.map((column) => [column, snapshot.itemOrderByColumn[column].filter((id) => id !== nextItem.id)]),
-  ) as Record<WorkItemColumn, string[]>;
-  const nextColumnItems = nextItemOrderByColumn[nextItem.column];
-  const normalizedIndex = targetIndex == null
-    ? previousIndex >= 0 ? Math.min(previousIndex, nextColumnItems.length) : nextColumnItems.length
-    : Math.max(0, Math.min(targetIndex, nextColumnItems.length));
-  nextColumnItems.splice(normalizedIndex, 0, nextItem.id);
-
-  return {
-    ...snapshot,
-    items: {
-      ...snapshot.items,
-      [nextItem.id]: {
-        ...nextItem,
-        updatedAt: timestamp,
-      },
-    },
-    itemOrderByColumn: nextItemOrderByColumn,
-  };
-}
-
-function buildSplitDescription(item: WorkItem): string {
-  const prefix = `Split from "${item.title}".`;
-  return item.description ? `${prefix}\n\n${item.description}` : prefix;
+export interface WorkItemWorkflowStore {
+  createWorkItem(input: CreateWorkItemInput): Promise<WorkItem | null>;
+  deleteWorkItem(itemId: string): Promise<boolean>;
+  getColumnDefinitions(): readonly WorkItemColumnDefinition[];
+  getColumnLabel(column: WorkItemColumn): string;
+  getSummary(requestedSelectedItemId?: string | null): Promise<WorkItemStoreSummary>;
+  getWorkItem(itemId: string): Promise<WorkItem | null>;
+  moveItemToColumn(itemId: string, toColumn: WorkItemColumn, targetIndex?: number): Promise<WorkItem | null>;
+  reorderItems(
+    itemId: string,
+    fromColumn: WorkItemColumn,
+    toColumn: WorkItemColumn,
+    targetIndex: number,
+  ): Promise<boolean>;
+  splitWorkItem(itemId: string, input: SplitWorkItemInput): Promise<WorkItem | null>;
+  toggleColumnCollapsed(column: WorkItemColumn): Promise<boolean>;
+  updateWorkItem(itemId: string, updates: UpdateWorkItemInput): Promise<WorkItem | null>;
 }
 
 class CorruptSnapshotError extends Error {

--- a/src/workItems/adapter.ts
+++ b/src/workItems/adapter.ts
@@ -1,0 +1,88 @@
+import type {
+  CreateWorkItemInput,
+  PersistedWorkItemSnapshot,
+  SnapshotValidationIssue,
+  SplitWorkItemInput,
+  UpdateWorkItemInput,
+  WorkItem,
+} from "./types";
+import type { WorkItemColumn } from "./constants";
+import type {
+  WorkItemBoardColumn,
+  WorkItemColumnDefinition,
+  WorkItemColumnSummary,
+  WorkItemSelectionState,
+} from "./board";
+
+export interface WorkItemPromptContext {
+  readonly description: string | null;
+  readonly title: string;
+}
+
+export interface WorkItemSourceParser {
+  createEmptySnapshot(): PersistedWorkItemSnapshot;
+  listSnapshotIssues(value: unknown): SnapshotValidationIssue[];
+  parseSnapshot(value: unknown): PersistedWorkItemSnapshot;
+}
+
+export interface WorkItemSourceMover {
+  createItem(snapshot: PersistedWorkItemSnapshot, input: CreateWorkItemInput): {
+    readonly item: WorkItem;
+    readonly snapshot: PersistedWorkItemSnapshot;
+  };
+  deleteItem(snapshot: PersistedWorkItemSnapshot, itemId: string): {
+    readonly deleted: boolean;
+    readonly snapshot: PersistedWorkItemSnapshot;
+  };
+  moveItemToColumn(
+    snapshot: PersistedWorkItemSnapshot,
+    itemId: string,
+    toColumn: WorkItemColumn,
+    targetIndex: number,
+  ): {
+    readonly item: WorkItem | null;
+    readonly snapshot: PersistedWorkItemSnapshot;
+  };
+  reorderItems(
+    snapshot: PersistedWorkItemSnapshot,
+    itemId: string,
+    fromColumn: WorkItemColumn,
+    toColumn: WorkItemColumn,
+    targetIndex: number,
+  ): {
+    readonly reordered: boolean;
+    readonly snapshot: PersistedWorkItemSnapshot;
+  };
+  splitItem(snapshot: PersistedWorkItemSnapshot, itemId: string, input: SplitWorkItemInput): {
+    readonly item: WorkItem | null;
+    readonly snapshot: PersistedWorkItemSnapshot;
+  };
+  toggleColumnCollapsed(snapshot: PersistedWorkItemSnapshot, column: WorkItemColumn): PersistedWorkItemSnapshot;
+  updateItem(snapshot: PersistedWorkItemSnapshot, itemId: string, updates: UpdateWorkItemInput): {
+    readonly item: WorkItem | null;
+    readonly snapshot: PersistedWorkItemSnapshot;
+  };
+}
+
+export interface WorkItemSourceRenderer {
+  renderBoardColumns(snapshot: PersistedWorkItemSnapshot): readonly WorkItemBoardColumn[];
+  renderColumnSummaries(snapshot: PersistedWorkItemSnapshot): readonly WorkItemColumnSummary[];
+  resolveSelectionState(snapshot: PersistedWorkItemSnapshot, selectedItemId: string | null): WorkItemSelectionState;
+}
+
+export interface WorkItemSourcePromptBuilder {
+  buildContextPrompt(context: WorkItemPromptContext): string;
+}
+
+export interface WorkItemSourceConfig {
+  getColumnDefinitions(): readonly WorkItemColumnDefinition[];
+  getStoragePath(workspaceRootPath: string): string;
+}
+
+export interface WorkItemSourceAdapter {
+  readonly config: WorkItemSourceConfig;
+  readonly mover: WorkItemSourceMover;
+  readonly parser: WorkItemSourceParser;
+  readonly promptBuilder: WorkItemSourcePromptBuilder;
+  readonly renderer: WorkItemSourceRenderer;
+}

--- a/src/workItems/board.ts
+++ b/src/workItems/board.ts
@@ -1,0 +1,55 @@
+import type { WorkItemColumn, WorkItemState } from "./constants";
+
+export interface WorkItemColumnDefinition {
+  readonly id: WorkItemColumn;
+  readonly label: string;
+}
+
+export interface WorkItemColumnSummary {
+  readonly id: WorkItemColumn;
+  readonly label: string;
+  readonly count: number;
+}
+
+export interface WorkItemBoardCard {
+  readonly blockerReason: string | null;
+  readonly column: WorkItemColumn;
+  readonly completedAt: string | null;
+  readonly createdAt: string;
+  readonly description: string | null;
+  readonly id: string;
+  readonly isBlocked: boolean;
+  readonly priorityDeadline: string | null;
+  readonly priorityLevel: string;
+  readonly priorityScore: number;
+  readonly sourceCapturedAt: string | null;
+  readonly sourceExternalId: string | null;
+  readonly sourceKind: string;
+  readonly sourcePath: string | null;
+  readonly sourceUrl: string | null;
+  readonly state: WorkItemState;
+  readonly title: string;
+  readonly updatedAt: string;
+}
+
+export interface WorkItemBoardColumn {
+  readonly id: WorkItemColumn;
+  readonly items: readonly WorkItemBoardCard[];
+  readonly label: string;
+}
+
+export interface WorkItemSelectionState {
+  readonly selectedItem: WorkItemBoardCard | null;
+  readonly selectedItemId: string | null;
+}
+
+export interface WorkItemStoreSummary {
+  readonly boardColumns: readonly WorkItemBoardColumn[];
+  readonly collapsedColumns: Record<WorkItemColumn, boolean>;
+  readonly columnSummaries: readonly WorkItemColumnSummary[];
+  readonly latestWorkItemTitle: string | null;
+  readonly selectedItem: WorkItemBoardCard | null;
+  readonly selectedItemId: string | null;
+  readonly storagePath: string | null;
+  readonly totalCount: number;
+}

--- a/src/workItems/builtInJsonAdapter.ts
+++ b/src/workItems/builtInJsonAdapter.ts
@@ -1,0 +1,442 @@
+import { join } from "node:path";
+
+import {
+  WORK_ITEM_COLUMNS,
+  type WorkItemColumn,
+  type WorkItemState,
+} from "./constants";
+import {
+  createEmptyPersistedWorkItemSnapshot,
+  listPersistedWorkItemSnapshotIssues,
+  normalizePersistedWorkItemSnapshot,
+} from "./snapshot";
+import {
+  createWorkItem,
+  normalizeOptionalString,
+  normalizePriorityLevel,
+  normalizePriorityScore,
+  normalizeSourceKind,
+  normalizeTimestamp,
+} from "./createWorkItem";
+import type {
+  CreateWorkItemInput,
+  PersistedWorkItemSnapshot,
+  SplitWorkItemInput,
+  UpdateWorkItemInput,
+  WorkItem,
+} from "./types";
+import type { WorkItemSourceAdapter } from "./adapter";
+import type {
+  WorkItemBoardCard,
+  WorkItemBoardColumn,
+  WorkItemColumnDefinition,
+  WorkItemColumnSummary,
+  WorkItemSelectionState,
+} from "./board";
+
+const STORAGE_DIRECTORY_NAME = ".work-terminal";
+const STORAGE_FILE_NAME = "work-items.v1.json";
+
+const COLUMN_DEFINITIONS: readonly WorkItemColumnDefinition[] = [
+  { id: "priority", label: "Priority" },
+  { id: "todo", label: "To Do" },
+  { id: "active", label: "Active" },
+  { id: "done", label: "Done" },
+] as const;
+
+export function createBuiltInJsonWorkItemSourceAdapter(): WorkItemSourceAdapter {
+  return {
+    config: {
+      getColumnDefinitions(): readonly WorkItemColumnDefinition[] {
+        return COLUMN_DEFINITIONS;
+      },
+      getStoragePath(workspaceRootPath: string): string {
+        return join(workspaceRootPath, STORAGE_DIRECTORY_NAME, STORAGE_FILE_NAME);
+      },
+    },
+    parser: {
+      createEmptySnapshot(): PersistedWorkItemSnapshot {
+        return createEmptyPersistedWorkItemSnapshot();
+      },
+      listSnapshotIssues(value: unknown) {
+        return listPersistedWorkItemSnapshotIssues(value);
+      },
+      parseSnapshot(value: unknown): PersistedWorkItemSnapshot {
+        return normalizePersistedWorkItemSnapshot(value);
+      },
+    },
+    mover: {
+      createItem(snapshot: PersistedWorkItemSnapshot, input: CreateWorkItemInput) {
+        const item = createWorkItem(input);
+        return {
+          item,
+          snapshot: {
+            ...snapshot,
+            items: {
+              ...snapshot.items,
+              [item.id]: item,
+            },
+            itemOrderByColumn: {
+              ...snapshot.itemOrderByColumn,
+              [item.column]: [item.id, ...snapshot.itemOrderByColumn[item.column].filter((id) => id !== item.id)],
+            },
+          },
+        };
+      },
+      deleteItem(snapshot: PersistedWorkItemSnapshot, itemId: string) {
+        if (!snapshot.items[itemId]) {
+          return {
+            deleted: false,
+            snapshot,
+          };
+        }
+
+        const nextItems = { ...snapshot.items };
+        delete nextItems[itemId];
+
+        return {
+          deleted: true,
+          snapshot: {
+            ...snapshot,
+            items: nextItems,
+            itemOrderByColumn: Object.fromEntries(
+              WORK_ITEM_COLUMNS.map((column) => [column, snapshot.itemOrderByColumn[column].filter((id) => id !== itemId)]),
+            ) as Record<WorkItemColumn, string[]>,
+          },
+        };
+      },
+      moveItemToColumn(snapshot: PersistedWorkItemSnapshot, itemId: string, toColumn: WorkItemColumn, targetIndex: number) {
+        const item = snapshot.items[itemId];
+        if (!item) {
+          return {
+            item: null,
+            snapshot,
+          };
+        }
+
+        const normalizedIndex = Math.max(0, Math.min(targetIndex, snapshot.itemOrderByColumn[toColumn].length));
+        const timestamp = new Date().toISOString();
+        const nextState = item.column === toColumn ? item.state : getStateForColumn(toColumn);
+        const nextItem: WorkItem = {
+          ...item,
+          column: toColumn,
+          state: nextState,
+          updatedAt: timestamp,
+          completedAt: toColumn === "done"
+            ? item.completedAt ?? timestamp
+            : null,
+        };
+
+        return {
+          item: nextItem,
+          snapshot: moveItemWithinSnapshot(snapshot, nextItem, timestamp, normalizedIndex),
+        };
+      },
+      reorderItems(
+        snapshot: PersistedWorkItemSnapshot,
+        itemId: string,
+        fromColumn: WorkItemColumn,
+        toColumn: WorkItemColumn,
+        targetIndex: number,
+      ) {
+        const item = snapshot.items[itemId];
+        if (!item || item.column !== fromColumn) {
+          return {
+            reordered: false,
+            snapshot,
+          };
+        }
+
+        const nextState = fromColumn === toColumn ? item.state : getStateForColumn(toColumn);
+        const normalizedIndex = Math.max(0, Math.min(targetIndex, snapshot.itemOrderByColumn[toColumn].length));
+        const nextItemOrderByColumn = Object.fromEntries(
+          WORK_ITEM_COLUMNS.map((column) => [column, snapshot.itemOrderByColumn[column].filter((id) => id !== itemId)]),
+        ) as Record<WorkItemColumn, string[]>;
+
+        nextItemOrderByColumn[toColumn].splice(normalizedIndex, 0, itemId);
+
+        const timestamp = new Date().toISOString();
+        const nextItem: WorkItem = {
+          ...item,
+          column: toColumn,
+          state: nextState,
+          updatedAt: timestamp,
+          completedAt: toColumn === "done" ? item.completedAt ?? timestamp : null,
+        };
+
+        return {
+          reordered: true,
+          snapshot: {
+            ...snapshot,
+            items: {
+              ...snapshot.items,
+              [itemId]: nextItem,
+            },
+            itemOrderByColumn: nextItemOrderByColumn,
+          },
+        };
+      },
+      splitItem(snapshot: PersistedWorkItemSnapshot, itemId: string, input: SplitWorkItemInput) {
+        const item = snapshot.items[itemId];
+        if (!item) {
+          return {
+            item: null,
+            snapshot,
+          };
+        }
+
+        const fallbackState = item.column === "done" ? "todo" : item.state;
+        const nextDescription = normalizeOptionalString(input.description) ?? buildSplitDescription(item);
+        const nextItem = createWorkItem({
+          title: input.title,
+          description: nextDescription,
+          state: input.state ?? fallbackState,
+          source: { ...item.source },
+          priority: { ...item.priority },
+          now: input.now,
+        });
+        const nextColumn = nextItem.column;
+        const existingOrder = snapshot.itemOrderByColumn[nextColumn].filter((id) => id !== nextItem.id);
+        const parentIndex = nextColumn === item.column ? existingOrder.indexOf(item.id) : -1;
+        const insertionIndex = parentIndex >= 0 ? parentIndex + 1 : 0;
+        const nextOrder = [...existingOrder];
+        nextOrder.splice(insertionIndex, 0, nextItem.id);
+
+        return {
+          item: nextItem,
+          snapshot: {
+            ...snapshot,
+            items: {
+              ...snapshot.items,
+              [nextItem.id]: nextItem,
+            },
+            itemOrderByColumn: {
+              ...snapshot.itemOrderByColumn,
+              [nextColumn]: nextOrder,
+            },
+          },
+        };
+      },
+      toggleColumnCollapsed(snapshot: PersistedWorkItemSnapshot, column: WorkItemColumn) {
+        return {
+          ...snapshot,
+          collapsedColumns: {
+            ...snapshot.collapsedColumns,
+            [column]: !snapshot.collapsedColumns[column],
+          },
+        };
+      },
+      updateItem(snapshot: PersistedWorkItemSnapshot, itemId: string, updates: UpdateWorkItemInput) {
+        const item = snapshot.items[itemId];
+        if (!item) {
+          return {
+            item: null,
+            snapshot,
+          };
+        }
+
+        const timestamp = normalizeTimestamp(updates.now, new Date().toISOString());
+        const nextState = updates.state ? normalizeState(updates.state) : item.state;
+        const nextColumn = getColumnForState(nextState);
+        const requestedBlocked = updates.priority?.isBlocked;
+        const nextBlocked = requestedBlocked == null ? item.priority.isBlocked : Boolean(requestedBlocked);
+        const nextItem: WorkItem = {
+          ...item,
+          title: updates.title == null ? item.title : normalizeOptionalString(updates.title) ?? item.title,
+          description: updates.description === undefined ? item.description : normalizeOptionalString(updates.description),
+          state: nextState,
+          column: nextColumn,
+          source: {
+            kind: updates.source?.kind == null ? item.source.kind : normalizeSourceKind(updates.source.kind),
+            externalId: updates.source?.externalId === undefined
+              ? item.source.externalId
+              : normalizeOptionalString(updates.source.externalId),
+            url: updates.source?.url === undefined
+              ? item.source.url
+              : normalizeOptionalString(updates.source.url),
+            path: updates.source?.path === undefined
+              ? item.source.path
+              : normalizeOptionalString(updates.source.path),
+            fingerprint: updates.source?.fingerprint === undefined
+              ? item.source.fingerprint
+              : normalizeOptionalString(updates.source.fingerprint),
+            capturedAt: updates.source?.capturedAt === undefined
+              ? item.source.capturedAt
+              : normalizeOptionalString(updates.source.capturedAt),
+          },
+          priority: {
+            level: updates.priority?.level == null ? item.priority.level : normalizePriorityLevel(updates.priority.level),
+            score: updates.priority?.score == null ? item.priority.score : normalizePriorityScore(updates.priority.score),
+            deadline: updates.priority?.deadline === undefined
+              ? item.priority.deadline
+              : normalizeOptionalString(updates.priority.deadline),
+            isBlocked: nextBlocked,
+            blockerReason: nextBlocked
+              ? updates.priority?.blockerReason === undefined
+                ? item.priority.blockerReason
+                : normalizeOptionalString(updates.priority.blockerReason)
+              : null,
+          },
+          updatedAt: timestamp,
+          completedAt: nextColumn === "done"
+            ? item.completedAt ?? timestamp
+            : null,
+        };
+
+        return {
+          item: nextItem,
+          snapshot: moveItemWithinSnapshot(snapshot, nextItem, timestamp),
+        };
+      },
+    },
+    promptBuilder: {
+      buildContextPrompt({ description, title }) {
+        const lines = [
+          "Work item context:",
+          `- Title: ${title}`,
+        ];
+
+        if (description?.trim()) {
+          lines.push(`- Description: ${description.trim()}`);
+        }
+
+        lines.push("", "Start by confirming the task understanding and proposing the next concrete step.");
+
+        return lines.join("\n");
+      },
+    },
+    renderer: {
+      renderBoardColumns(snapshot: PersistedWorkItemSnapshot): readonly WorkItemBoardColumn[] {
+        return COLUMN_DEFINITIONS.map((columnDefinition) => ({
+          id: columnDefinition.id,
+          items: snapshot.itemOrderByColumn[columnDefinition.id]
+            .map((id) => snapshot.items[id])
+            .filter((item): item is WorkItem => Boolean(item))
+            .map(renderBoardCard),
+          label: columnDefinition.label,
+        }));
+      },
+      renderColumnSummaries(snapshot: PersistedWorkItemSnapshot): readonly WorkItemColumnSummary[] {
+        return COLUMN_DEFINITIONS.map((columnDefinition) => ({
+          id: columnDefinition.id,
+          label: columnDefinition.label,
+          count: snapshot.itemOrderByColumn[columnDefinition.id].length,
+        }));
+      },
+      resolveSelectionState(snapshot: PersistedWorkItemSnapshot, selectedItemId: string | null): WorkItemSelectionState {
+        const orderedItems = getOrderedItems(snapshot);
+        const selectedItem = selectedItemId
+          ? orderedItems.find((item) => item.id === selectedItemId) ?? null
+          : null;
+        const resolvedItem = selectedItem ?? orderedItems[0] ?? null;
+
+        return {
+          selectedItem: resolvedItem ? renderBoardCard(resolvedItem) : null,
+          selectedItemId: resolvedItem?.id ?? null,
+        };
+      },
+    },
+  };
+}
+
+function renderBoardCard(item: WorkItem): WorkItemBoardCard {
+  return {
+    blockerReason: item.priority.blockerReason,
+    column: item.column,
+    completedAt: item.completedAt,
+    createdAt: item.createdAt,
+    description: item.description,
+    id: item.id,
+    isBlocked: item.priority.isBlocked,
+    priorityDeadline: item.priority.deadline,
+    priorityLevel: item.priority.level,
+    priorityScore: item.priority.score,
+    sourceCapturedAt: item.source.capturedAt,
+    sourceExternalId: item.source.externalId,
+    sourceKind: item.source.kind,
+    sourcePath: item.source.path,
+    sourceUrl: item.source.url,
+    state: item.state,
+    title: item.title,
+    updatedAt: item.updatedAt,
+  };
+}
+
+function getOrderedItems(snapshot: PersistedWorkItemSnapshot): readonly WorkItem[] {
+  return COLUMN_DEFINITIONS.flatMap((columnDefinition) =>
+    snapshot.itemOrderByColumn[columnDefinition.id]
+      .map((id) => snapshot.items[id])
+      .filter((item): item is WorkItem => Boolean(item))
+  );
+}
+
+function getColumnForState(state: WorkItemState): WorkItemColumn {
+  switch (state) {
+    case "priority":
+      return "priority";
+    case "todo":
+      return "todo";
+    case "active":
+      return "active";
+    case "done":
+    case "abandoned":
+      return "done";
+  }
+}
+
+function getStateForColumn(column: WorkItemColumn): WorkItemState {
+  switch (column) {
+    case "priority":
+      return "priority";
+    case "todo":
+      return "todo";
+    case "active":
+      return "active";
+    case "done":
+      return "done";
+  }
+}
+
+function normalizeState(state: WorkItemState): WorkItemState {
+  return state === "priority" ||
+    state === "todo" ||
+    state === "active" ||
+    state === "done" ||
+    state === "abandoned"
+    ? state
+    : "todo";
+}
+
+function moveItemWithinSnapshot(
+  snapshot: PersistedWorkItemSnapshot,
+  nextItem: WorkItem,
+  timestamp: string,
+  targetIndex?: number,
+): PersistedWorkItemSnapshot {
+  const previousIndex = snapshot.itemOrderByColumn[nextItem.column].indexOf(nextItem.id);
+  const nextItemOrderByColumn = Object.fromEntries(
+    WORK_ITEM_COLUMNS.map((column) => [column, snapshot.itemOrderByColumn[column].filter((id) => id !== nextItem.id)]),
+  ) as Record<WorkItemColumn, string[]>;
+  const nextColumnItems = nextItemOrderByColumn[nextItem.column];
+  const normalizedIndex = targetIndex == null
+    ? previousIndex >= 0 ? Math.min(previousIndex, nextColumnItems.length) : nextColumnItems.length
+    : Math.max(0, Math.min(targetIndex, nextColumnItems.length));
+  nextColumnItems.splice(normalizedIndex, 0, nextItem.id);
+
+  return {
+    ...snapshot,
+    items: {
+      ...snapshot.items,
+      [nextItem.id]: {
+        ...nextItem,
+        updatedAt: timestamp,
+      },
+    },
+    itemOrderByColumn: nextItemOrderByColumn,
+  };
+}
+
+function buildSplitDescription(item: WorkItem): string {
+  const prefix = `Split from "${item.title}".`;
+  return item.description ? `${prefix}\n\n${item.description}` : prefix;
+}

--- a/src/workItems/index.ts
+++ b/src/workItems/index.ts
@@ -32,12 +32,26 @@ export {
   normalizePersistedWorkItemSnapshot,
 } from "./snapshot";
 export {
-  WorkItemStore,
+  createBuiltInJsonWorkItemSourceAdapter,
+} from "./builtInJsonAdapter";
+export {
+  type WorkItemSourceAdapter,
+  type WorkItemSourceConfig,
+  type WorkItemSourceMover,
+  type WorkItemSourceParser,
+  type WorkItemSourcePromptBuilder,
+  type WorkItemSourceRenderer,
+  type WorkItemPromptContext,
+} from "./adapter";
+export {
   type WorkItemBoardCard,
   type WorkItemBoardColumn,
+  type WorkItemColumnDefinition,
   type WorkItemColumnSummary,
+  type WorkItemSelectionState,
   type WorkItemStoreSummary,
-} from "./WorkItemStore";
+} from "./board";
+export { WorkItemStore, type WorkItemWorkflowStore } from "./WorkItemStore";
 export type {
   CreateWorkItemInput,
   PersistedWorkItemSnapshot,

--- a/src/workTerminal/WorkTerminalViewProvider.ts
+++ b/src/workTerminal/WorkTerminalViewProvider.ts
@@ -13,9 +13,10 @@ import type { TerminalSessionStore } from "../terminals";
 import type {
   WorkItem,
   WorkItemColumn,
+  WorkItemColumnDefinition,
   WorkItemPriorityLevel,
   WorkItemSourceKind,
-  WorkItemStore,
+  WorkItemWorkflowStore,
 } from "../workItems";
 import { getNonce } from "./getNonce";
 import {
@@ -70,7 +71,7 @@ export class WorkTerminalViewProvider implements vscode.WebviewViewProvider {
   public constructor(
     private readonly extensionUri: vscode.Uri,
     private readonly disposables: vscode.Disposable[],
-    private readonly store: WorkItemStore,
+    private readonly store: WorkItemWorkflowStore,
     private readonly terminalStore: TerminalSessionStore,
   ) {
     this.disposables.push(
@@ -242,7 +243,7 @@ export class WorkTerminalViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    const state = await promptForState();
+    const state = await promptForState(this.store.getColumnDefinitions());
     if (!state) {
       return;
     }
@@ -415,7 +416,7 @@ export class WorkTerminalViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    const targetColumn = await promptForMoveColumn(item.column);
+    const targetColumn = await promptForMoveColumn(item.column, this.store.getColumnDefinitions());
     if (!targetColumn) {
       return;
     }
@@ -426,7 +427,7 @@ export class WorkTerminalViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    await this.refresh(`Moved "${moved.title}" to ${labelForColumn(targetColumn)}`);
+    await this.refresh(`Moved "${moved.title}" to ${this.store.getColumnLabel(targetColumn)}`);
   }
 
   public async splitWorkItemFromPrompt(itemId: string): Promise<void> {
@@ -544,7 +545,7 @@ export class WorkTerminalViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    const action = await promptForWorkItemAction(item);
+    const action = await promptForWorkItemAction(item, this.store.getColumnDefinitions());
     switch (action) {
       case "delete":
         await this.deleteWorkItemFromPrompt(itemId);
@@ -704,12 +705,8 @@ export class WorkTerminalViewProvider implements vscode.WebviewViewProvider {
   }
 
   private async createViewState(status: string): Promise<WorkTerminalViewState> {
-    const summary = await this.store.getSummary();
-    const allItems = summary.boardColumns.flatMap((column) => column.items);
-    const resolvedSelectedItemId = allItems.some((item) => item.id === this.selectedItemId)
-      ? this.selectedItemId
-      : allItems[0]?.id ?? null;
-    this.selectedItemId = resolvedSelectedItemId;
+    const summary = await this.store.getSummary(this.selectedItemId);
+    this.selectedItemId = summary.selectedItemId;
     const terminalSummary = this.terminalStore.getSummary();
 
     return {
@@ -720,7 +717,8 @@ export class WorkTerminalViewProvider implements vscode.WebviewViewProvider {
       latestWorkItemTitle: summary.latestWorkItemTitle,
       profileIssues: terminalSummary.profileIssues,
       recentlyClosedSessions: terminalSummary.recentlyClosedSessions,
-      selectedItemId: resolvedSelectedItemId,
+      selectedItem: summary.selectedItem,
+      selectedItemId: summary.selectedItemId,
       status,
       storagePath: summary.storagePath,
       terminalSessionCountByItemId: terminalSummary.sessionCountByItemId,
@@ -756,20 +754,20 @@ export class WorkTerminalViewProvider implements vscode.WebviewViewProvider {
   }
 }
 
-async function promptForState(): Promise<"priority" | "todo" | "active" | "done" | undefined> {
-  const choices = [
-    { label: "To Do", state: "todo" },
-    { label: "Active", state: "active" },
-    { label: "Priority", state: "priority" },
-    { label: "Done", state: "done" },
-  ] as const;
+async function promptForState(
+  columnDefinitions: readonly WorkItemColumnDefinition[],
+): Promise<"priority" | "todo" | "active" | "done" | undefined> {
+  const choices = columnDefinitions.map((columnDefinition) => ({
+    label: columnDefinition.label,
+    state: columnDefinition.id,
+  }));
 
   const selection = await vscode.window.showQuickPick(choices, {
     ignoreFocusOut: true,
     placeHolder: "Choose the initial state",
   });
 
-  return selection?.state;
+  return selection?.state as "priority" | "todo" | "active" | "done" | undefined;
 }
 
 async function promptForProfileAction(): Promise<"create" | "delete" | "edit" | "move-down" | "move-up" | "reset" | undefined> {
@@ -1009,18 +1007,20 @@ async function promptForSourceKind(currentKind: WorkItemSourceKind): Promise<Wor
   return selection?.value;
 }
 
-async function promptForMoveColumn(currentColumn: WorkItemColumn): Promise<WorkItemColumn | undefined> {
-  const options = [
-    { description: "Move to the Priority column", label: "Priority", value: "priority" },
-    { description: "Move to the To Do column", label: "To Do", value: "todo" },
-    { description: "Move to the Active column", label: "Active", value: "active" },
-    { description: "Move to the Done column", label: "Done", value: "done" },
-  ] as const;
+async function promptForMoveColumn(
+  currentColumn: WorkItemColumn,
+  columnDefinitions: readonly WorkItemColumnDefinition[],
+): Promise<WorkItemColumn | undefined> {
+  const options = columnDefinitions.map((columnDefinition) => ({
+    description: `Move to the ${columnDefinition.label} column`,
+    label: columnDefinition.label,
+    value: columnDefinition.id,
+  }));
   const selection = await vscode.window.showQuickPick(
     options.filter((option) => option.value !== currentColumn),
     {
       ignoreFocusOut: true,
-      placeHolder: `Move work item from ${labelForColumn(currentColumn)}`,
+      placeHolder: `Move work item from ${labelForColumn(currentColumn, columnDefinitions)}`,
     },
   );
 
@@ -1029,7 +1029,10 @@ async function promptForMoveColumn(currentColumn: WorkItemColumn): Promise<WorkI
 
 type WorkItemAction = "delete" | "edit-details" | "edit-metadata" | "move" | "open-source" | "split";
 
-async function promptForWorkItemAction(item: WorkItem): Promise<WorkItemAction | undefined> {
+async function promptForWorkItemAction(
+  item: WorkItem,
+  columnDefinitions: readonly WorkItemColumnDefinition[],
+): Promise<WorkItemAction | undefined> {
   const options = [
     {
       description: "Edit the title and description",
@@ -1042,7 +1045,7 @@ async function promptForWorkItemAction(item: WorkItem): Promise<WorkItemAction |
       value: "edit-metadata",
     },
     {
-      description: `Current column: ${labelForColumn(item.column)}`,
+      description: `Current column: ${labelForColumn(item.column, columnDefinitions)}`,
       label: "Move item",
       value: "move",
     },
@@ -1097,17 +1100,8 @@ function validateOptionalUriInput(value: string): string | null {
   }
 }
 
-function labelForColumn(column: WorkItemColumn): string {
-  switch (column) {
-    case "priority":
-      return "Priority";
-    case "todo":
-      return "To Do";
-    case "active":
-      return "Active";
-    case "done":
-      return "Done";
-  }
+function labelForColumn(column: WorkItemColumn, columnDefinitions: readonly WorkItemColumnDefinition[]): string {
+  return columnDefinitions.find((columnDefinition) => columnDefinition.id === column)?.label ?? column;
 }
 
 function resolveSourcePath(pathValue: string): vscode.Uri {

--- a/src/workTerminal/renderWorkTerminalHtml.ts
+++ b/src/workTerminal/renderWorkTerminalHtml.ts
@@ -45,6 +45,26 @@ export interface WorkTerminalViewState {
     readonly message: string;
     readonly profileId: string | null;
   }>;
+  readonly selectedItem: {
+    readonly blockerReason: string | null;
+    readonly column: string;
+    readonly completedAt: string | null;
+    readonly createdAt: string;
+    readonly description: string | null;
+    readonly id: string;
+    readonly isBlocked: boolean;
+    readonly priorityDeadline: string | null;
+    readonly priorityLevel: string;
+    readonly priorityScore: number;
+    readonly sourceCapturedAt: string | null;
+    readonly sourceExternalId: string | null;
+    readonly sourceKind: string;
+    readonly sourcePath: string | null;
+    readonly sourceUrl: string | null;
+    readonly state: string;
+    readonly title: string;
+    readonly updatedAt: string;
+  } | null;
   readonly selectedItemId: string | null;
   readonly recentlyClosedSessions: ReadonlyArray<{
     readonly closedAt: string;

--- a/test/agents/AgentProfile.test.ts
+++ b/test/agents/AgentProfile.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  buildWorkItemContextPrompt,
   getBuiltInAgentProfileById,
   getBuiltInAgentProfiles,
   getResumeBehaviorLabel,
@@ -27,15 +26,5 @@ describe("AgentProfile", () => {
   it("describes resume behavior for custom and built-in kinds", () => {
     expect(getResumeBehaviorLabel({ kind: "custom", usesContext: false })).toContain("configured agent command");
     expect(getResumeBehaviorLabel({ kind: "strands", usesContext: true })).toContain("sends work item context");
-  });
-
-  it("builds a work item context prompt with a description", () => {
-    expect(buildWorkItemContextPrompt("Fix flaky test", "Investigate CI failures")).toContain(
-      "- Description: Investigate CI failures",
-    );
-  });
-
-  it("omits the description line when none is present", () => {
-    expect(buildWorkItemContextPrompt("Fix flaky test", null)).not.toContain("- Description:");
   });
 });

--- a/test/renderWorkTerminalHtml.test.ts
+++ b/test/renderWorkTerminalHtml.test.ts
@@ -4,6 +4,26 @@ import { renderWorkTerminalHtml } from "../src/workTerminal/renderWorkTerminalHt
 
 describe("renderWorkTerminalHtml", () => {
   it("renders the expected bootstrap shell", () => {
+    const selectedItem = {
+      blockerReason: null,
+      column: "active",
+      completedAt: null,
+      createdAt: "2026-04-01T09:00:00.000Z",
+      description: "Test selection details",
+      id: "123e4567-e89b-12d3-a456-426614174000",
+      isBlocked: false,
+      priorityDeadline: "2026-04-02T10:00:00.000Z",
+      priorityLevel: "medium",
+      priorityScore: 42,
+      sourceCapturedAt: "2026-04-01T09:05:00.000Z",
+      sourceExternalId: "ISSUE-24",
+      sourceKind: "manual",
+      sourcePath: "notes/demo.md",
+      sourceUrl: "https://example.invalid/items/24",
+      state: "active",
+      title: "Demo task",
+      updatedAt: "2026-04-01T10:00:00.000Z",
+    } as const;
     const html = renderWorkTerminalHtml({
       cspSource: "https://example.invalid",
       nonce: "test-nonce",
@@ -25,28 +45,7 @@ describe("renderWorkTerminalHtml", () => {
         boardColumns: [
           {
             id: "active",
-            items: [
-              {
-                blockerReason: null,
-                column: "active",
-                completedAt: null,
-                createdAt: "2026-04-01T09:00:00.000Z",
-                description: "Test selection details",
-                id: "123e4567-e89b-12d3-a456-426614174000",
-                isBlocked: false,
-                priorityDeadline: "2026-04-02T10:00:00.000Z",
-                priorityLevel: "medium",
-                priorityScore: 42,
-                sourceCapturedAt: "2026-04-01T09:05:00.000Z",
-                sourceExternalId: "ISSUE-24",
-                sourceKind: "manual",
-                sourcePath: "notes/demo.md",
-                sourceUrl: "https://example.invalid/items/24",
-                state: "active",
-                title: "Demo task",
-                updatedAt: "2026-04-01T10:00:00.000Z",
-              },
-            ],
+            items: [selectedItem],
             label: "Active",
           },
         ],
@@ -63,9 +62,10 @@ describe("renderWorkTerminalHtml", () => {
         latestWorkItemTitle: "Demo task",
         profileIssues: [],
         recentlyClosedSessions: [],
+        selectedItem,
         selectedItemId: "123e4567-e89b-12d3-a456-426614174000",
         status: "Ready",
-        storagePath: "/tmp/workspace/.work-terminal/work-items.v1.json",
+        storagePath: "/workspace/.work-terminal/work-items.v1.json",
         terminalSessionCountByItemId: {
           "123e4567-e89b-12d3-a456-426614174000": 1,
         },
@@ -106,6 +106,26 @@ describe("renderWorkTerminalHtml", () => {
   });
 
   it("escapes line separator characters in the bootstrapped state", () => {
+    const selectedItem = {
+      blockerReason: "Waiting on API rollout",
+      column: "active",
+      completedAt: null,
+      createdAt: "2026-04-01T09:00:00.000Z",
+      description: "Line\u2028separator and paragraph\u2029separator",
+      id: "123e4567-e89b-12d3-a456-426614174000",
+      isBlocked: false,
+      priorityDeadline: null,
+      priorityLevel: "medium",
+      priorityScore: 7,
+      sourceCapturedAt: null,
+      sourceExternalId: null,
+      sourceKind: "manual",
+      sourcePath: null,
+      sourceUrl: null,
+      state: "active",
+      title: "Demo\u2028task",
+      updatedAt: "2026-04-01T10:00:00.000Z",
+    } as const;
     const html = renderWorkTerminalHtml({
       cspSource: "https://example.invalid",
       nonce: "test-nonce",
@@ -115,28 +135,7 @@ describe("renderWorkTerminalHtml", () => {
         boardColumns: [
           {
             id: "active",
-            items: [
-              {
-                blockerReason: "Waiting on API rollout",
-                column: "active",
-                completedAt: null,
-                createdAt: "2026-04-01T09:00:00.000Z",
-                description: "Line\u2028separator and paragraph\u2029separator",
-                id: "123e4567-e89b-12d3-a456-426614174000",
-                isBlocked: false,
-                priorityDeadline: null,
-                priorityLevel: "medium",
-                priorityScore: 7,
-                sourceCapturedAt: null,
-                sourceExternalId: null,
-                sourceKind: "manual",
-                sourcePath: null,
-                sourceUrl: null,
-                state: "active",
-                title: "Demo\u2028task",
-                updatedAt: "2026-04-01T10:00:00.000Z",
-              },
-            ],
+            items: [selectedItem],
             label: "Active",
           },
         ],
@@ -150,6 +149,7 @@ describe("renderWorkTerminalHtml", () => {
         latestWorkItemTitle: "Demo\u2029task",
         profileIssues: [],
         recentlyClosedSessions: [],
+        selectedItem,
         selectedItemId: "123e4567-e89b-12d3-a456-426614174000",
         status: "Ready",
         storagePath: null,

--- a/test/terminals/TerminalSessionStore.test.ts
+++ b/test/terminals/TerminalSessionStore.test.ts
@@ -191,6 +191,38 @@ describe("TerminalSessionStore", () => {
     store.dispose();
   });
 
+  it("uses the injected work item prompt builder for context-aware agent sessions", async () => {
+    configurationValues.claudeCommand = process.execPath;
+
+    const { TerminalSessionStore } = await import("../../src/terminals");
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "work-terminal-terminal-store-"));
+    tempDirectories.push(workspaceRoot);
+    const promptBuilder = {
+      buildContextPrompt: vi.fn(() => "Adapter supplied prompt"),
+    };
+    const store = new TerminalSessionStore(workspaceRoot, promptBuilder);
+
+    const result = await store.createAgentSession({
+      cwd: "/workspace",
+      itemDescription: "Look into the regression",
+      itemId: "item-1",
+      itemTitle: "Investigate regression",
+      profileId: "claude-context",
+    });
+
+    expect(result.error).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(promptBuilder.buildContextPrompt).toHaveBeenCalledWith({
+      description: "Look into the regression",
+      title: "Investigate regression",
+    });
+    expect(createdTerminals[0].sendText).toHaveBeenCalledWith("Adapter supplied prompt", true);
+
+    store.dispose();
+  });
+
   it("does not send a delayed prompt after the terminal has already closed", async () => {
     configurationValues.claudeCommand = process.execPath;
 

--- a/test/workItems/WorkItemAdapter.test.ts
+++ b/test/workItems/WorkItemAdapter.test.ts
@@ -1,0 +1,81 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createBuiltInJsonWorkItemSourceAdapter,
+  WorkItemStore,
+  type WorkItemColumnDefinition,
+} from "../../src/workItems";
+
+const tempDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) => rm(directory, { force: true, recursive: true })),
+  );
+});
+
+describe("work item adapters", () => {
+  it("builds context prompts through the built-in adapter prompt builder", () => {
+    const adapter = createBuiltInJsonWorkItemSourceAdapter();
+
+    expect(adapter.promptBuilder.buildContextPrompt({
+      description: "Investigate CI failures",
+      title: "Fix flaky test",
+    })).toContain("- Description: Investigate CI failures");
+    expect(adapter.promptBuilder.buildContextPrompt({
+      description: null,
+      title: "Fix flaky test",
+    })).not.toContain("- Description:");
+  });
+
+  it("renders board summaries through the injected adapter abstraction", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "work-terminal-adapter-store-"));
+    tempDirectories.push(workspaceRoot);
+
+    const builtInAdapter = createBuiltInJsonWorkItemSourceAdapter();
+    const customColumns: readonly WorkItemColumnDefinition[] = [
+      { id: "priority", label: "Queue" },
+      { id: "todo", label: "Planned" },
+      { id: "active", label: "Doing" },
+      { id: "done", label: "Shipped" },
+    ];
+    const renderBoardColumns = vi.fn((snapshot) => builtInAdapter.renderer.renderBoardColumns(snapshot).map((column) => ({
+      ...column,
+      label: customColumns.find((customColumn) => customColumn.id === column.id)?.label ?? column.label,
+    })));
+    const renderColumnSummaries = vi.fn((snapshot) => builtInAdapter.renderer.renderColumnSummaries(snapshot).map((column) => ({
+      ...column,
+      label: customColumns.find((customColumn) => customColumn.id === column.id)?.label ?? column.label,
+    })));
+    const resolveSelectionState = vi.fn((snapshot, selectedItemId) =>
+      builtInAdapter.renderer.resolveSelectionState(snapshot, selectedItemId)
+    );
+
+    const store = new WorkItemStore(workspaceRoot, {
+      ...builtInAdapter,
+      config: {
+        ...builtInAdapter.config,
+        getColumnDefinitions: () => customColumns,
+      },
+      renderer: {
+        renderBoardColumns,
+        renderColumnSummaries,
+        resolveSelectionState,
+      },
+    });
+
+    await store.createWorkItem({ title: "Use adapter labels" });
+    const summary = await store.getSummary();
+
+    expect(renderBoardColumns).toHaveBeenCalledTimes(1);
+    expect(renderColumnSummaries).toHaveBeenCalledTimes(1);
+    expect(resolveSelectionState).toHaveBeenCalledWith(expect.anything(), null);
+    expect(summary.boardColumns.find((column) => column.id === "todo")?.label).toBe("Planned");
+    expect(summary.columnSummaries.find((column) => column.id === "done")?.label).toBe("Shipped");
+    expect(store.getColumnLabel("active")).toBe("Doing");
+  });
+});

--- a/test/workItems/WorkItemStore.test.ts
+++ b/test/workItems/WorkItemStore.test.ts
@@ -295,4 +295,36 @@ describe("WorkItemStore", () => {
     expect(snapshot.items[abandonedItem!.id]?.state).toBe("abandoned");
     expect(snapshot.items[activeItem!.id]?.state).toBe("done");
   });
+
+  it("resolves selected item detail state through the adapter renderer", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "work-terminal-store-"));
+    tempDirectories.push(workspaceRoot);
+
+    const store = new WorkItemStore(workspaceRoot);
+    await store.createWorkItem({ title: "First item" });
+    const second = await store.createWorkItem({
+      description: "Preferred detail selection",
+      priority: {
+        blockerReason: "Waiting on review",
+        isBlocked: true,
+        level: "high",
+        score: 55,
+      },
+      title: "Second item",
+    });
+
+    const selectedSummary = await store.getSummary(second!.id);
+    expect(selectedSummary.selectedItemId).toBe(second!.id);
+    expect(selectedSummary.selectedItem).toMatchObject({
+      blockerReason: "Waiting on review",
+      id: second!.id,
+      isBlocked: true,
+      title: "Second item",
+    });
+
+    const fallbackSummary = await store.getSummary("missing-id");
+    const expectedFallbackId = fallbackSummary.boardColumns.flatMap((column) => column.items)[0]?.id ?? null;
+    expect(fallbackSummary.selectedItemId).toBe(expectedFallbackId);
+    expect(fallbackSummary.selectedItem?.id).toBe(expectedFallbackId);
+  });
 });

--- a/test/workTerminal/WorkTerminalViewProvider.test.ts
+++ b/test/workTerminal/WorkTerminalViewProvider.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { WorkItemWorkflowStore, WorkItemStoreSummary } from "../../src/workItems";
+
+const getConfiguration = vi.fn(() => ({
+  update: vi.fn(),
+}));
+
+vi.mock("vscode", () => {
+  class Disposable {
+    public constructor(private readonly callback: () => void) {}
+
+    public dispose(): void {
+      this.callback();
+    }
+  }
+
+  return {
+    ConfigurationTarget: {
+      Global: 1,
+      Workspace: 2,
+    },
+    Disposable,
+    Uri: {
+      joinPath: (...segments: Array<{ readonly path?: string } | string>) => ({
+        path: segments.map((segment) => typeof segment === "string" ? segment : segment.path ?? "").join("/"),
+        toString() {
+          return this.path;
+        },
+      }),
+    },
+    window: {},
+    workspace: {
+      getConfiguration,
+      name: "Demo workspace",
+      workspaceFolders: [{ name: "Demo workspace", uri: { fsPath: "/workspace" } }],
+    },
+  };
+});
+
+describe("WorkTerminalViewProvider", () => {
+  it("uses adapter-resolved selection state from the workflow store", async () => {
+    const { WorkTerminalViewProvider } = await import("../../src/workTerminal/WorkTerminalViewProvider");
+
+    const summary: WorkItemStoreSummary = {
+      boardColumns: [
+        {
+          id: "todo",
+          items: [
+            {
+              blockerReason: null,
+              column: "todo",
+              completedAt: null,
+              createdAt: "2026-04-01T09:00:00.000Z",
+              description: "Visible board card",
+              id: "item-a",
+              isBlocked: false,
+              priorityDeadline: null,
+              priorityLevel: "medium",
+              priorityScore: 20,
+              sourceCapturedAt: null,
+              sourceExternalId: null,
+              sourceKind: "manual",
+              sourcePath: null,
+              sourceUrl: null,
+              state: "todo",
+              title: "Item A",
+              updatedAt: "2026-04-01T10:00:00.000Z",
+            },
+          ],
+          label: "To Do",
+        },
+      ],
+      collapsedColumns: {
+        active: false,
+        done: false,
+        priority: false,
+        todo: false,
+      },
+      columnSummaries: [{ count: 1, id: "todo", label: "To Do" }],
+      latestWorkItemTitle: "Item A",
+      selectedItem: {
+        blockerReason: "Adapter-chosen detail",
+        column: "todo",
+        completedAt: null,
+        createdAt: "2026-04-01T09:30:00.000Z",
+        description: "Resolved by adapter selection logic",
+        id: "item-b",
+        isBlocked: true,
+        priorityDeadline: null,
+        priorityLevel: "high",
+        priorityScore: 88,
+        sourceCapturedAt: null,
+        sourceExternalId: "ISSUE-25",
+        sourceKind: "jira",
+        sourcePath: null,
+        sourceUrl: "https://example.invalid/issues/25",
+        state: "active",
+        title: "Adapter detail item",
+        updatedAt: "2026-04-01T11:00:00.000Z",
+      },
+      selectedItemId: "item-b",
+      storagePath: "/workspace/.work-terminal/work-items.v1.json",
+      totalCount: 2,
+    };
+    const store: WorkItemWorkflowStore = {
+      createWorkItem: vi.fn(),
+      deleteWorkItem: vi.fn(),
+      getColumnDefinitions: vi.fn(() => []),
+      getColumnLabel: vi.fn((column: string) => column),
+      getSummary: vi.fn(async () => summary),
+      getWorkItem: vi.fn(),
+      moveItemToColumn: vi.fn(),
+      reorderItems: vi.fn(),
+      splitWorkItem: vi.fn(),
+      toggleColumnCollapsed: vi.fn(),
+      updateWorkItem: vi.fn(),
+    };
+    const terminalStore = {
+      getSummary: vi.fn(() => ({
+        agentProfiles: [],
+        profileIssues: [],
+        recentlyClosedSessions: [],
+        sessionCountByItemId: {},
+        sessions: [],
+      })),
+      onDidChangeSessions: vi.fn(() => ({ dispose() {} })),
+    };
+
+    const provider = new WorkTerminalViewProvider(
+      { path: "/extension" } as never,
+      [],
+      store,
+      terminalStore as never,
+    );
+
+    const state = await (provider as unknown as { createViewState(status: string): Promise<Record<string, unknown>> }).createViewState("Ready");
+
+    expect(store.getSummary).toHaveBeenCalledWith(null);
+    expect(state.selectedItemId).toBe("item-b");
+    expect(state.selectedItem).toMatchObject({
+      blockerReason: "Adapter-chosen detail",
+      id: "item-b",
+      title: "Adapter detail item",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- introduce adapter interfaces and a built-in JSON work-item source implementation
- refactor the workflow store, view provider, rendering, and prompt flow to depend on adapter-backed work-item semantics
- add regression coverage and docs for the adapter-driven architecture

## Testing
- pnpm check
- pnpm build