### PR TITLE
Add adapter architecture for work-item sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The extension-host side owns VS Code API integration, persistence, terminal life
 - `src/agents/AgentProfile.ts` - defines the built-in Claude, Copilot, and Strands defaults
 - `src/agents/AgentProfileConfiguration.ts` - loads profile settings, validates custom profiles, and serializes profile edits
 
-The built-in adapter keeps the current `.work-terminal/work-items.v1.json` behavior as the default source. The extension-host framework now depends on adapter interfaces for snapshot parsing, board rendering, selected-item detail resolution, column movement, context prompting, and source configuration so future task-file-backed adapters can slot in without reworking the board or terminal layers.
+The built-in adapter keeps the current `.work-terminal/work-items.v1.json` behavior as the default source. The extension-host framework now depends on adapter interfaces for snapshot parsing, board rendering, selected-item detail resolution, column movement, context prompting, and source configuration. Today that boundary is still snapshot-backed, but it is shaped so future task-file-backed adapters can map their own semantics into the framework without rewriting the board or terminal layers.
 
 ### Webview
 

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -304,7 +304,11 @@ root.addEventListener("click", (event: MouseEvent) => {
   const card = target.closest<HTMLElement>("[data-work-item-id]");
   if (card) {
     const itemId = card.dataset.workItemId ?? null;
-    applyState({ ...state, selectedItemId: itemId });
+    applyState({
+      ...state,
+      selectedItem: findBoardItemById(state, itemId),
+      selectedItemId: itemId,
+    });
     vscode.postMessage({ type: "work-item-selected", itemId });
   }
 });
@@ -748,11 +752,22 @@ function getActionableSelectedItem(
   visibleItems: WorkTerminalViewState["boardColumns"][number]["items"] | null = null,
 ): WorkTerminalViewState["boardColumns"][number]["items"][number] | null {
   if (query.trim().length === 0) {
-    return nextState.selectedItem;
+    return findBoardItemById(nextState, nextState.selectedItemId) ?? nextState.selectedItem;
   }
 
   const actionableItems = visibleItems ?? getVisibleBoardColumns(nextState, query).flatMap((column) => column.items);
   return actionableItems.find((item) => item.id === nextState.selectedItemId) ?? null;
+}
+
+function findBoardItemById(
+  nextState: WorkTerminalViewState,
+  itemId: string | null,
+): WorkTerminalViewState["boardColumns"][number]["items"][number] | null {
+  if (!itemId) {
+    return null;
+  }
+
+  return nextState.boardColumns.flatMap((column) => column.items).find((item) => item.id === itemId) ?? null;
 }
 
 function captureFilterInputSnapshot(): FilterInputSnapshot {

--- a/test/terminals/TerminalSessionStore.test.ts
+++ b/test/terminals/TerminalSessionStore.test.ts
@@ -341,9 +341,11 @@ describe("TerminalSessionStore", () => {
 
     closeListeners[0]?.(createdTerminals[0]);
     await waitForPersistedSessionCount(store, 0);
-    expect(onChange).toHaveBeenCalledTimes(2);
-    expect(store.getSummary().sessions).toHaveLength(0);
-    expect(store.getSummary().recentlyClosedSessions).toHaveLength(1);
+    await vi.waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(store.getSummary().sessions).toHaveLength(0);
+      expect(store.getSummary().recentlyClosedSessions).toHaveLength(1);
+    });
 
     disposable.dispose();
     store.dispose();

--- a/test/workTerminal/WorkTerminalViewProvider.test.ts
+++ b/test/workTerminal/WorkTerminalViewProvider.test.ts
@@ -15,12 +15,36 @@ vi.mock("vscode", () => {
     }
   }
 
+  class EventEmitter<T> {
+    private readonly listeners = new Set<(value: T) => void>();
+
+    public get event(): (listener: (value: T) => void) => Disposable {
+      return (listener) => {
+        this.listeners.add(listener);
+        return new Disposable(() => {
+          this.listeners.delete(listener);
+        });
+      };
+    }
+
+    public fire(value: T): void {
+      for (const listener of this.listeners) {
+        listener(value);
+      }
+    }
+
+    public dispose(): void {
+      this.listeners.clear();
+    }
+  }
+
   return {
     ConfigurationTarget: {
       Global: 1,
       Workspace: 2,
     },
     Disposable,
+    EventEmitter,
     Uri: {
       joinPath: (...segments: Array<{ readonly path?: string } | string>) => ({
         path: segments.map((segment) => typeof segment === "string" ? segment : segment.path ?? "").join("/"),
@@ -29,7 +53,20 @@ vi.mock("vscode", () => {
         },
       }),
     },
-    window: {},
+    window: {
+      createTerminal: vi.fn((options: { readonly name?: string } | undefined) => ({
+        dispose: vi.fn(),
+        name: options?.name ?? "Terminal",
+        sendText: vi.fn(),
+        show: vi.fn(),
+        state: {
+          isInteractedWith: false,
+        },
+      })),
+      onDidChangeTerminalState: vi.fn(() => new Disposable(() => {})),
+      onDidCloseTerminal: vi.fn(() => new Disposable(() => {})),
+      terminals: [],
+    },
     workspace: {
       getConfiguration,
       name: "Demo workspace",


### PR DESCRIPTION
## Summary
- keep optimistic selected-item detail state in sync with the highlighted board card
- cover the adapter-driven provider path and async close-event timing in tests
- retain the updated adapter architecture docs wording

## Validation
- pnpm check
- pnpm build

Refs #25